### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,10 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "c029678b-9b9f-4fb2-958f-3a118efa16a9",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -16,7 +19,10 @@
       ]
     },
     {
+      "uuid": "8bfa54a8-4ee6-4e6e-b286-7fc8c70b9e9f",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -26,7 +32,10 @@
       ]
     },
     {
+      "uuid": "eb3a92bf-0748-4406-ba67-9e27e367ae45",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Variables",
@@ -35,7 +44,10 @@
       ]
     },
     {
+      "uuid": "25506c31-7274-402a-95e1-8475fcdb34e1",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Variables",
@@ -46,7 +58,10 @@
       ]
     },
     {
+      "uuid": "1e6c8365-775d-4a4f-8fc7-e376912d7912",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -55,7 +70,10 @@
       ]
     },
     {
+      "uuid": "5c215cbf-a575-42ad-9b3f-892410a63077",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -64,7 +82,10 @@
       ]
     },
     {
+      "uuid": "79a4a35c-40d6-4e2d-92a1-005c40b4f4c5",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Variables",
@@ -73,7 +94,10 @@
       ]
     },
     {
+      "uuid": "424ed7aa-24f3-4aec-9620-3cc9dc224166",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -83,7 +107,10 @@
       ]
     },
     {
+      "uuid": "b5345fcb-d4cc-4ea0-b1b9-f1b0cb92f05c",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -92,7 +119,10 @@
       ]
     },
     {
+      "uuid": "841641f2-16ba-4dc5-af1b-ffae5052853a",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Interfaces",
@@ -103,7 +133,10 @@
       ]
     },
     {
+      "uuid": "d1d86b51-a3f4-4276-a18c-6db54bc8dfcc",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Interfaces",
@@ -112,7 +145,10 @@
       ]
     },
     {
+      "uuid": "52ac3dd0-8803-445f-93cf-e984b59d6702",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (loops)",
@@ -121,7 +157,10 @@
       ]
     },
     {
+      "uuid": "5c6f22e7-109c-4d9e-b8bf-4ea63b2823ca",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -131,7 +170,10 @@
       ]
     },
     {
+      "uuid": "d24cf0ea-876f-4775-969b-99970425e413",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Interfaces",
@@ -140,7 +182,10 @@
       ]
     },
     {
+      "uuid": "b9fd0f13-966c-4085-ac9d-ed49a96ac0bf",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Equality",
@@ -149,7 +194,10 @@
       ]
     },
     {
+      "uuid": "b2ad38c2-2962-4a47-9b14-20ca262ebff6",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (loops)",
@@ -159,7 +207,10 @@
       ]
     },
     {
+      "uuid": "6c702aa9-70f3-41d0-bc76-4323a08f8fbf",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -168,7 +219,10 @@
       ]
     },
     {
+      "uuid": "bd2a55e3-9874-4d2e-ad6f-4b2f8c5e2e0a",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -179,7 +233,10 @@
       ]
     },
     {
+      "uuid": "71804ace-6ca1-46b9-bf06-ff57faef7afa",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (loops)",
@@ -189,7 +246,10 @@
       ]
     },
     {
+      "uuid": "150d3608-d234-4c9e-ab6d-2d91f8a2c855",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -200,7 +260,10 @@
       ]
     },
     {
+      "uuid": "f350f23d-72f8-4f47-a0f5-fe3c00f3f5f1",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (loops)",
@@ -210,7 +273,10 @@
       ]
     },
     {
+      "uuid": "005ff8b4-9df8-4b82-b919-a0c67356d654",
       "slug": "binary",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -219,7 +285,10 @@
       ]
     },
     {
+      "uuid": "d2fd481e-7156-452d-976d-ea6df220fa18",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -229,7 +298,10 @@
       ]
     },
     {
+      "uuid": "40f3b911-0739-4fec-95cc-cfab99788c19",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -241,7 +313,10 @@
       ]
     },
     {
+      "uuid": "1a81aac9-9128-48ab-aa6a-4d981d6eb602",
       "slug": "strain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -251,7 +326,10 @@
       ]
     },
     {
+      "uuid": "71a1fdb6-414e-452c-8d24-03f2a5621e62",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -261,7 +339,10 @@
       ]
     },
     {
+      "uuid": "cc138097-7c0f-44b4-b07e-2a24f6475986",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -273,7 +354,10 @@
       ]
     },
     {
+      "uuid": "fcfc6b44-597d-4a03-bf02-6be5c8f7ae4e",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -284,7 +368,10 @@
       ]
     },
     {
+      "uuid": "ff3eb2c5-c7ce-4352-805c-e01d4fb85aa6",
       "slug": "trinary",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "Control-flow (conditionals)",
@@ -292,9 +379,6 @@
         "Mathematics"
       ]
     }
-  ],
-  "deprecated": [
-
   ],
   "foregone": [
     "accumulate",


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16