### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,11 @@
+(defpackage #:hamming
+  (:use #:common-lisp)
+  (:export #:distance))
+
+(in-package #:hamming)
+
+(defun distance (str1 str2 &key (test #'char=))
+  "Number of positional differences in two equal length strings."
+  (when (= (length str1) (length str2))
+    (count nil
+           (map 'list test str1 str2))))


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.

Note that we're aiming for 10 lines and a max-width of 40 columns.
This solution has 11 lines and a max-width of 65, so we may want to adjust it.

See https://github.com/exercism/meta/issues/89