### PR TITLE
Adding missing uuid to Pascal's Triangle exercise.

### DIFF
--- a/config.json
+++ b/config.json
@@ -378,6 +378,7 @@
       ]
     },
     {
+      "uuid": "34bc4fbe-f148-4519-a699-91efed432703",
       "slug": "pascals-triangle",
       "difficulty": 1,
       "topics": [


### PR DESCRIPTION
Fixes #172 