### PR TITLE
Fix invalid uuid

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
         "transforming"
       ],
       "unlocked_by": null,
-      "uuid": "6efa02be-0f9e-1d80-7efb-536d383535c98b1d883"
+      "uuid": "a999c375-f2e2-4d47-a9e2-5af923cd46d1"
     },
     {
       "core": true,


### PR DESCRIPTION
Configlet previously could generate invalid uuids.

It looks like `acronym` had an invalid uuid.