### PR TITLE
Acronym: remove HTML test case

### DIFF
--- a/exercises/acronym/acronym-test.lisp
+++ b/exercises/acronym/acronym-test.lisp
@@ -22,11 +22,6 @@
     "ROR"
     (acronym:acronym "Ruby on Rails")))
 
-(define-test html-test
-  (assert-equal
-    "HTML"
-    (acronym:acronym "HyperText Markup Language")))
-
 (define-test fifo-test
   (assert-equal
     "FIFO"


### PR DESCRIPTION
My usual approach to solving this exercise (split on hyphen or space, take all first characters and uppercase them) failed on the HTML example, which made me curious, so I dug a little deeper and found that the test case has been [removed from the canonical data](https://github.com/exercism/problem-specifications/pull/788).