### PR TITLE
Fix the getting started/help guide links to be correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ that fail tests
 ### Development setup
 
 Direct contributions to the Common Lisp code in xLisp are always welcome.
-Refer to [the Getting Started Guide](http://exercism.io/languages/lisp) for the
+Refer to [the Getting Started Guide](http://exercism.io/languages/common-lisp) for the
 Common Lisp track to get your environment set up if needed.
 
 New exercises or changes to existing ones can be submitted via a pull
@@ -104,4 +104,3 @@ error code if there are problems):
 The example implementation should use nothing outside of the Common
 Lisp specification. It should be well designed and not too clever.
 (Save the clever implementation for your submission on Exercism.io.)
-

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -6,7 +6,7 @@
 {{ end }}
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -9,7 +9,7 @@ like Portable Network Graphics to its acronym (PNG).
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -31,7 +31,7 @@ score is 257, your program should only report the eggs (1) allergy.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -8,7 +8,7 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -30,7 +30,7 @@ things based on word boundaries.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -322,7 +322,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -32,7 +32,7 @@ So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -15,7 +15,7 @@ He answers 'Whatever.' to anything else.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -6,8 +6,6 @@ Bob answers 'Sure.' if you ask him a question.
 
 He answers 'Whoa, chill out!' if you yell at him.
 
-He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
-
 He says 'Fine. Be that way!' if you address him without actually saying
 anything.
 

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -28,7 +28,7 @@ Resulting in 9 steps. So for input n = 12, the return value would be 9.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -52,7 +52,7 @@ Those spaces should be distributed evenly, added to the end of the last
 `n` chunks.
 
 ```text
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau
 ```
 
 Notice that were we to stack these, we could visually decode the
@@ -71,7 +71,7 @@ sseoau
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -52,7 +52,7 @@ Those spaces should be distributed evenly, added to the end of the last
 `n` chunks.
 
 ```text
-imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau 
 ```
 
 Notice that were we to stack these, we could visually decode the

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -14,7 +14,7 @@ natural numbers is 3025 - 385 = 2640.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -48,7 +48,7 @@ game while being scored at 4 in the Hawaiian-language version.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -6,7 +6,7 @@ A gigasecond is 10^9 (1,000,000,000) seconds.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -36,7 +36,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -28,7 +28,7 @@ experiment make the code better? Worse? Did you learn anything from it?
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -37,7 +37,7 @@ of equal length differently.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -16,7 +16,7 @@ If everything goes well, you will be ready to fetch your first real exercise.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -15,7 +15,7 @@ The word *isograms*, however, is not an isogram, because the s repeats.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -28,7 +28,7 @@ phenomenon, go watch [this youtube video][video].
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -28,7 +28,7 @@ descriptor calculate the date of the actual meetup.  For example, if given
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -14,7 +14,7 @@ Here is an analogy:
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -16,7 +16,7 @@ the right and left of the current position in the previous row.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -19,7 +19,7 @@ Implement a way to determine whether a given number is **perfect**. Depending on
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -30,7 +30,7 @@ should all produce the output
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -31,7 +31,7 @@ You can check this yourself:
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -19,7 +19,7 @@ Convert a number to a string, the contents of which depend on the number's facto
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -20,7 +20,7 @@ each nucleotide with its complement:
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -17,7 +17,7 @@ every existing robot has a unique name.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -44,7 +44,7 @@ See also: http://www.novaroma.org/via_romana/numbers.html
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -41,7 +41,7 @@ And to total:
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -29,7 +29,7 @@ correct list of primes.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -19,7 +19,7 @@ youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -35,7 +35,7 @@ basic tools instead.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -19,7 +19,7 @@ Examples:
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -24,7 +24,7 @@ a single line. Feel free to add your own code/tests to check for degenerate tria
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -23,7 +23,7 @@ conversion, pretend it doesn't exist and implement it yourself.
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -13,7 +13,7 @@ free: 1
 
 ## Setup
 
-Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+Check out [Exercism Help](http://exercism.io/languages/common-lisp) for instructions to
 get started writing Common Lisp. That page will explain how to install and setup
 a Lisp implementation and how to run the tests.
 


### PR DESCRIPTION
Guess: At one point this track was called lisp not common-lisp.