### PR TITLE
difference-of-sums: rename square-of-sums to square-of-sum

### DIFF
--- a/exercises/difference-of-squares/difference-of-squares-test.lisp
+++ b/exercises/difference-of-squares/difference-of-squares-test.lisp
@@ -6,22 +6,22 @@
 
 (in-package #:squares-test)
 
-(define-test square-of-sums-to-5
-  (assert-equal 225 (squares:square-of-sums 5)))
+(define-test square-of-sum-to-5
+  (assert-equal 225 (squares:square-of-sum 5)))
 (define-test sum-of-squares-to-5
   (assert-equal 55 (squares:sum-of-squares 5)))
 (define-test difference-of-sums-to-5
   (assert-equal 170 (squares:difference 5)))
 
-(define-test square-of-sums-to-10
-  (assert-equal 3025 (squares:square-of-sums 10)))
+(define-test square-of-sum-to-10
+  (assert-equal 3025 (squares:square-of-sum 10)))
 (define-test sum-of-squares-to-10
   (assert-equal 385 (squares:sum-of-squares 10)))
 (define-test difference-of-sums-to-10
   (assert-equal 2640 (squares:difference 10)))
 
-(define-test square-of-sums-to-100
-  (assert-equal 25502500 (squares:square-of-sums 100)))
+(define-test square-of-sum-to-100
+  (assert-equal 25502500 (squares:square-of-sum 100)))
 (define-test sum-of-squares-to-100
   (assert-equal 338350 (squares:sum-of-squares 100)))
 (define-test difference-of-sums-to-100

--- a/exercises/difference-of-squares/example.lisp
+++ b/exercises/difference-of-squares/example.lisp
@@ -1,17 +1,17 @@
 (defpackage #:squares
   (:use #:cl)
   (:export #:sum-of-squares
-           #:square-of-sums
+           #:square-of-sum
            #:difference))
 
 (in-package #:squares)
 
-(defun square-of-sums (n)
+(defun square-of-sum (n)
   (expt (* 1/2 n (1+ n)) 2))
 
 (defun sum-of-squares (n)
   (* 1/6 n (1+ n) (1+ (* 2 n))))
 
 (defun difference (n)
-  (- (square-of-sums n)
+  (- (square-of-sum n)
      (sum-of-squares n)))


### PR DESCRIPTION
In the exercise "difference-of-sums", renamed `square-of-sums` to `square-of-sum`.