### PR TITLE
Fix Hello World exercise.

### DIFF
--- a/exercises/hello-world/example.lisp
+++ b/exercises/hello-world/example.lisp
@@ -5,5 +5,4 @@
 
 (in-package #:hello-world)
 
-(defun hello-world (&optional name)
-  (format nil "Hello ~A!" (or name "World")))
+(defun hello-world () "Hello, World!")

--- a/exercises/hello-world/hello-world-test.lisp
+++ b/exercises/hello-world/hello-world-test.lisp
@@ -7,13 +7,7 @@
 (in-package #:hello-world-test)
 
 (define-test hello-world-test
-  (assert-equal "Hello World!" (hw:hello-world)))
-
-(define-test hello-alice-test
-  (assert-equal "Hello Alice!" (hw:hello-world "Alice")))
-
-(define-test hello-bob-test
-  (assert-equal "Hello Bob!" (hw:hello-world "Bob")))
+  (assert-equal "Hello, World!" (hw:hello-world)))
 
 #-xlisp-test
 (let ((*print-errors* t)


### PR DESCRIPTION
It did not match the canonical data. The example implementation was
more complicated than it needed to be after the tests were changed to
their canonical form.

Fixes #222 