### PR TITLE
Fix indent-tabs-mode instructions

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -41,7 +41,7 @@ powerful add-on packages available. The only thing that one needs to
 do with a stock emacs to make it work well with exercism.io is to
 evaluate the following code:
 
-`(setq-default indent-tab-mode nil)`
+`(setq-default indent-tabs-mode nil)`
 
 This can be placed in your `~/.emacs` (or `~/.emacs.d/init.el`) in
 order to have it set whenever Emacs is launched.


### PR DESCRIPTION
A minor spelling error in the instructions for setting indent-tabs-mode in emacs.