### PR TITLE
Rename square-of-sums to square-of-sum to match the tests

### DIFF
--- a/exercises/difference-of-squares/squares.lisp
+++ b/exercises/difference-of-squares/squares.lisp
@@ -1,7 +1,7 @@
 (defpackage #:squares
   (:use #:cl)
   (:export #:sum-of-squares
-           #:square-of-sums
+           #:square-of-sum
            #:difference))
 
 (in-package #:squares)


### PR DESCRIPTION
The tests use `square-of-sum`, but the `squares` package exports `square-of-sums`. This fixes the typo.