### PR TITLE
Adjust core track to help ease bottlenecks

### DIFF
--- a/config.json
+++ b/config.json
@@ -45,6 +45,18 @@
       ]
     },
     {
+      "slug": "rna-transcription",
+      "uuid": "5c215cbf-a575-42ad-9b3f-892410a63077",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
       "slug": "leap",
       "uuid": "8bfa54a8-4ee6-4e6e-b286-7fc8c70b9e9f",
       "core": true,
@@ -58,38 +70,13 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "1e6c8365-775d-4a4f-8fc7-e376912d7912",
+      "slug": "anagram",
+      "uuid": "b9fd0f13-966c-4085-ac9d-ed49a96ac0bf",
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control_flow_conditionals",
-        "parsing",
-        "strings"
-      ]
-    },
-    {
-      "slug": "rna-transcription",
-      "uuid": "5c215cbf-a575-42ad-9b3f-892410a63077",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "424ed7aa-24f3-4aec-9620-3cc9dc224166",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "equality",
         "filtering",
         "strings"
       ]
@@ -108,18 +95,6 @@
       ]
     },
     {
-      "slug": "anagram",
-      "uuid": "b9fd0f13-966c-4085-ac9d-ed49a96ac0bf",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "equality",
-        "filtering",
-        "strings"
-      ]
-    },
-    {
       "slug": "roman-numerals",
       "uuid": "150d3608-d234-4c9e-ab6d-2d91f8a2c855",
       "core": true,
@@ -131,6 +106,31 @@
         "integers",
         "strings",
         "text_formatting"
+      ]
+    },
+    {
+      "slug": "word-count",
+      "uuid": "424ed7aa-24f3-4aec-9620-3cc9dc224166",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "1e6c8365-775d-4a4f-8fc7-e376912d7912",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "parsing",
+        "strings"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -31,6 +31,109 @@
       ]
     },
     {
+      "slug": "hamming",
+      "uuid": "c029678b-9b9f-4fb2-958f-3a118efa16a9",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "equality",
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "leap",
+      "uuid": "8bfa54a8-4ee6-4e6e-b286-7fc8c70b9e9f",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "equality",
+        "integers",
+        "logic"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "1e6c8365-775d-4a4f-8fc7-e376912d7912",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "parsing",
+        "strings"
+      ]
+    },
+    {
+      "slug": "rna-transcription",
+      "uuid": "5c215cbf-a575-42ad-9b3f-892410a63077",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "strings",
+        "transforming"
+      ]
+    },
+    {
+      "slug": "word-count",
+      "uuid": "424ed7aa-24f3-4aec-9620-3cc9dc224166",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "beer-song",
+      "uuid": "5c6f22e7-109c-4d9e-b8bf-4ea63b2823ca",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "anagram",
+      "uuid": "b9fd0f13-966c-4085-ac9d-ed49a96ac0bf",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "equality",
+        "filtering",
+        "strings"
+      ]
+    },
+    {
+      "slug": "roman-numerals",
+      "uuid": "150d3608-d234-4c9e-ab6d-2d91f8a2c855",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "integers",
+        "strings",
+        "text_formatting"
+      ]
+    },
+    {
       "slug": "luhn",
       "uuid": "7cc9d827-b08e-437d-826e-244f220feca0",
       "core": false,
@@ -78,20 +181,6 @@
       ]
     },
     {
-      "slug": "hamming",
-      "uuid": "c029678b-9b9f-4fb2-958f-3a118efa16a9",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "equality",
-        "filtering",
-        "strings"
-      ]
-    },
-    {
       "slug": "sublist",
       "uuid": "428e5b28-31b6-4c84-8eae-d7753d45efc1",
       "core": false,
@@ -99,19 +188,6 @@
       "difficulty": 1,
       "topics": [
         "lists"
-      ]
-    },
-    {
-      "slug": "leap",
-      "uuid": "8bfa54a8-4ee6-4e6e-b286-7fc8c70b9e9f",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "equality",
-        "integers",
-        "logic"
       ]
     },
     {
@@ -140,30 +216,6 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "1e6c8365-775d-4a4f-8fc7-e376912d7912",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "parsing",
-        "strings"
-      ]
-    },
-    {
-      "slug": "rna-transcription",
-      "uuid": "5c215cbf-a575-42ad-9b3f-892410a63077",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "strings",
-        "transforming"
-      ]
-    },
-    {
       "slug": "robot-name",
       "uuid": "79a4a35c-40d6-4e2d-92a1-005c40b4f4c5",
       "core": false,
@@ -173,19 +225,6 @@
         "randomness",
         "strings",
         "variables"
-      ]
-    },
-    {
-      "slug": "word-count",
-      "uuid": "424ed7aa-24f3-4aec-9620-3cc9dc224166",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "filtering",
-        "strings"
       ]
     },
     {
@@ -239,19 +278,6 @@
       ]
     },
     {
-      "slug": "beer-song",
-      "uuid": "5c6f22e7-109c-4d9e-b8bf-4ea63b2823ca",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "text_formatting"
-      ]
-    },
-    {
       "slug": "space-age",
       "uuid": "d24cf0ea-876f-4775-969b-99970425e413",
       "core": false,
@@ -261,18 +287,6 @@
         "floating_point_numbers",
         "interfaces",
         "transforming"
-      ]
-    },
-    {
-      "slug": "anagram",
-      "uuid": "b9fd0f13-966c-4085-ac9d-ed49a96ac0bf",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "equality",
-        "filtering",
-        "strings"
       ]
     },
     {
@@ -357,20 +371,6 @@
         "floating_point_numbers",
         "integers",
         "math"
-      ]
-    },
-    {
-      "slug": "roman-numerals",
-      "uuid": "150d3608-d234-4c9e-ab6d-2d91f8a2c855",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "integers",
-        "strings",
-        "text_formatting"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -25,8 +25,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "strings",
         "optional_values",
+        "strings",
         "text_formatting"
       ]
     },

--- a/config.json
+++ b/config.json
@@ -415,7 +415,7 @@
     {
       "slug": "sieve",
       "uuid": "40f3b911-0739-4fec-95cc-cfab99788c19",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [


### PR DESCRIPTION
**TL;DR:**
This PR reorders the core exercises; see the end for the new ordering.
Please read the full thing before replying!

---

I wrote a script that takes some data points into account to move certain core exercises to be optional side exercises, and which reorders the remaining exercises.

This is not meant to be the "be all end all" of perfection :-)
This is an attempt to make some simple changes in the short term. In the longer term, over the next 12 months, the product team will be doing a bunch of work to dig into what makes great Exercism exercises, and how to structure tracks to provide a better experience for both learners and mentors.

**Once this goes live** we will continue to monitor the continuation rate, the median wait time, and a few other stats as well, to help decide whether or not we need to take any other immediate steps. That said, if you see anything weird or worrying once the change is out, please ping us on Slack (or here) so we can discuss a fix posthaste!

**The most helpful thing you can do in reviewing this** is to look at the results and tell me whether anything is obviously terrible or suspiciously weird. I know very little about the Common Lisp track (or the language, for that matter), so I could easily have missed something.

I'd also appreciate it if you posted this to the mentors as a heads up, and also because mentors tend to have a great gut sense about the core exercises.

## Bottleneck detection and fixes
### Removal from core:

The `sieve` exercise was moved out of the core track.

This is taken from a list of exercises that typically are unappealing to students and not very interesting to mentor. They tend to be math problems or implementations of CS algorithms and the like. However, if you think sieve is particularly useful to this track, then let me know and I can regenerate the PR, leaving sieve in place.

### Reordering:

The data that I based the reordering on was taken from the production database, and is based on the last 6 months.

I reordered by taking the original order, and then giving "penalty points" for two different things

- low continuation rates (percentage)
- long wait times in the mentor queue (median wait time in minutes)

"Continuation" is when someone completes an exercise, but then does not submit the following exercise. We have other interesting numbers that we may use to adjust things in the future, but this one seemed like our best bet for now for the bottlenecks. I somewhat arbitrarily chose 75% as the cutoff for whether or not to give penalty points, i.e. continuation rate < 75% gets penalized. The only exercise I did not penalize based on this rate was the exercise directly following `hello-world`, since `hello-world` is basically just a taste test, and it is natural to assume that many people will decide that Exercism is not really for them.

<details>
 <summary>Continuation rates</summary>

```
- hello-world (100%)
- two-fer (43%)
- hamming (100%)
- leap (95%)
- bob (72%)
- rna-transcription (100%)
- word-count (77%)
- beer-song (91%)
- anagram (100%)
- roman-numerals (89%)
- sieve (100%)
```

</details>

Long wait times in the mentor queue is an indication that mentors don't enjoy mentoring the exercise, or put it off. This could be for a number of reasons, which we have not explicitly identified, but we've observed that sometimes the exercise is simply too difficult in the current position, which means that mentors have to go back and forth a whole bunch with students to get something right, and the discussions can be quite frustrating. Also sometimes the exercise is just not very interesting to mentor. Or if the exercise is too early in the track sometimes people will submit lots of really complicated solutions rather than a small handful of mostly reasonable solutions, also making it harder to mentor.

So this pushes exercises with long wait times further back in the core track. We may decide that we need to remove some exercises from core altogether, if wait times continue to be bad.

<details>
 <summary>Wait times</summary>

```
- hello-world (0 min)
- two-fer (2402 min)
- hamming (2586 min)
- leap (2874 min)
- bob (4439 min)
- rna-transcription (909 min)
- word-count (2431 min)
- beer-song (2186 min)
- anagram (1311 min)
- roman-numerals (1900 min)
- sieve (3327 min)
```
</details>

### Outcome

#### Before
```
- hello-world
- two-fer
- hamming
- leap
- bob
- rna-transcription
- word-count
- beer-song
- anagram
- roman-numerals
- sieve
```

#### After

_Note: the numbers indicate the position in the core track, as defined by the index of the array. Minus means that it moved earlier, plus means that it moved later._
```
- hello-world
- two-fer
- hamming
- rna-transcription (-2)
- leap (+1)
- anagram (-3)
- beer-song (-1)
- roman-numerals (-2)
- word-count (+2)
- bob (+5)
```
