### PR TITLE
Add main branch to workflows.

### DIFF
--- a/.github/workflows/configlet-lint.yml
+++ b/.github/workflows/configlet-lint.yml
@@ -3,7 +3,7 @@ name: configlet-lint
 on:
   push:
   pull_request:
-    branches: [master]
+    branches: [main, master]
 
 jobs:
   lint:

--- a/.github/workflows/run-exercise-tests.yml
+++ b/.github/workflows/run-exercise-tests.yml
@@ -3,7 +3,7 @@ name: exercise-tests
 on:
   push:
   pull_request:
-    branches: [master]
+    branches: [main, master]
 
 jobs:
   test:


### PR DESCRIPTION
Preparing for v3 - one change that we will be doing is to standardize the main branch as 'main'.