### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/concepts/anonymous-functions/about.md
+++ b/concepts/anonymous-functions/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on anonymous-functions concept

--- a/concepts/anonymous-functions/introduction.md
+++ b/concepts/anonymous-functions/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for anonymous-functions concept

--- a/concepts/arithmetic/about.md
+++ b/concepts/arithmetic/about.md
@@ -11,7 +11,7 @@ Common Lisp uses the standard arithmetic operators for most operations but is so
 
 While prefix notion turns some operations like `2 + 2` into the somewhat unfamiliar `(+ 2 2)` form, it makes it much easier to operate on more than one number at a time.
 
-### Arithmetic Operators With a Single Argument
+## Arithmetic Operators With a Single Argument
 
 As a small quirk, the `-` and `/` operators have a special meanings when applied to only one number:
 
@@ -24,7 +24,7 @@ As a small quirk, the `-` and `/` operators have a special meanings when applied
 (/ 0.1) ; => 10.0
 ```
 
-### Comparing Numbers
+## Comparing Numbers
 
 Finally, you may find it useful to compare different numbers using functions like `=` (equal), `/=` (not equal to), and `>=` (greater than or equal to). When these comparisons are true (as in `(= 1 1)`), they return `T` and when they aren't (as in `(> 0 1)`), they return `NIL`.
 

--- a/concepts/arithmetic/about.md
+++ b/concepts/arithmetic/about.md
@@ -1,3 +1,5 @@
+# About
+
 Common Lisp uses the standard arithmetic operators for most operations but is somewhat unique in using a "prefix-notation" as opposed to the more familiar "infix-notion". More visually:
 
 ```lisp

--- a/concepts/arithmetic/introduction.md
+++ b/concepts/arithmetic/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Common Lisp uses the standard arithmetic operators for most operations but is
 somewhat unique in using a "prefix-notation" as opposed to the more familiar
 "infix-notion". More visually:

--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on arrays concept

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for arrays concept

--- a/concepts/assignment/about.md
+++ b/concepts/assignment/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on assignment concept

--- a/concepts/assignment/introduction.md
+++ b/concepts/assignment/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for assignment concept

--- a/concepts/characters/about.md
+++ b/concepts/characters/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on characters concept

--- a/concepts/characters/introduction.md
+++ b/concepts/characters/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for characters concept

--- a/concepts/code-as-data/about.md
+++ b/concepts/code-as-data/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on code-as-data concept

--- a/concepts/code-as-data/introduction.md
+++ b/concepts/code-as-data/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for code-as-data concept

--- a/concepts/comments/about.md
+++ b/concepts/comments/about.md
@@ -1,3 +1,5 @@
+# About
+
 Single-line comments in Common Lisp follow a couple of conventions:
 
 ```lisp

--- a/concepts/comments/introduction.md
+++ b/concepts/comments/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Common Lisp allows the programmer to write "comments" that are ignored by the computer. Single-line comments begin with one or more semi-colons (`;`) and, occasionally, you may see the following:
 
 ```lisp

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -1,3 +1,5 @@
+# About
+
 Common Lisp provides the programmer with several different conditionals that can be categorised by the number of "branches" they support.
 
 Also, unlike many other programming languages, all conditionals in Common Lisp are _expressions_ not statements. This means that all Lisp conditionals evaluate to some value and can be substituted for concrete parameters.

--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -11,7 +11,7 @@ As an example:
 (* x (if (evenp x) 2 1))
 ```
 
-### Single-Branch Conditionals
+## Single-Branch Conditionals
 
 The conditionals `when` and `unless` evaluate some code only when the provided test is true or false respectively – evaluating to `nil` otherwise.
 
@@ -20,7 +20,7 @@ The conditionals `when` and `unless` evaluate some code only when the provided t
 (unless (= 2 2) "Time to panic!") ; => NIL
 ```
 
-### The Two-Branch Conditional
+## The Two-Branch Conditional
 
 The `if` conditional evaluates the first expression of the body when the test is true and the second one otherwise.
 
@@ -28,7 +28,7 @@ The `if` conditional evaluates the first expression of the body when the test is
 (if (= 2 2) 'how-honest 'you-liar) ; => HOW-HONEST
 ```
 
-### Many-Branch Conditionals
+## Many-Branch Conditionals
 
 The Lisp "super-conditional" is `cond`, which can have an infinite number of branches. Each branch has a test condition and body expression that are surrounded by an extra pair of parentheses. If all of the tests evaluate to false, then `nil` is returned.
 
@@ -52,7 +52,7 @@ If you just want to test one value against a number of branches, you can use the
 ; => "???"
 ```
 
-### The Stealth Conditionals
+## The Stealth Conditionals
 
 The boolean `and` and `or` operations in Common Lisp are short-circuiting macros
 that can be used to reduce the duplication of certain conditional
@@ -74,7 +74,7 @@ no true values:
 (or () NIL nil) ; => NIL
 ```
 
-### I'm Exhausted...
+## I'm Exhausted...
 
 As mentioned previously, when none of the branches in a `case` statement match,
 and there is no `otherwise` clause, `nil` is returned. Occasionally, however, a

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Common lisp provides several different conditional expressions, the main difference being the number of branches they support.
 
 - `when` and `unless` allow for a single branch:

--- a/concepts/cons/about.md
+++ b/concepts/cons/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Conses][hyper-conses] are a basic data type in Common Lisp. They are composed of a head and a tail (called for
 historical reason[1] the `car` and the `cdr`). There is no restriction on the data types of the head and tail of a cons.
 

--- a/concepts/cons/introduction.md
+++ b/concepts/cons/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 All Common Lisp code is either an "atom" (a single, indivisible value) or a list
 (also termed a "cons"). A cons is made up of two parts: the first element and
 the rest of the elements. For historical reasons these two parts are called the

--- a/concepts/constants/about.md
+++ b/concepts/constants/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on constants concept

--- a/concepts/constants/introduction.md
+++ b/concepts/constants/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for constants concept

--- a/concepts/default-parameters/about.md
+++ b/concepts/default-parameters/about.md
@@ -1,3 +1,5 @@
+# About
+
 An optional parameter is designated by the `&optional` lambda list keyword in a lambda list. Optional parameters are not required, can have a default and also can specify a "supplied-p parameter" which will be "true" or "false" depending on whether an argument was provided for the parameter.
 
 ```lisp

--- a/concepts/default-parameters/introduction.md
+++ b/concepts/default-parameters/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Common Lisp a function can have some arguments are are optional. These are designated in the lambda list by `&optional` lambda list keyword. A parameter will be bound to the value `nil` if it is not specified. If there are several optional parameters they are bound in order. Default values can be specified for optional parameters. Finally a symbol an be specified for each optional parameter which will be bound to true or false depending on whether that parameter was supplied by the caller of the function (this is referred to as the "supplied-p parameter").
 
 ```lisp

--- a/concepts/destructuring-assignment/about.md
+++ b/concepts/destructuring-assignment/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on destructuring-assignment concept

--- a/concepts/destructuring-assignment/introduction.md
+++ b/concepts/destructuring-assignment/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for destructuring-assignment concept

--- a/concepts/enumeration/about.md
+++ b/concepts/enumeration/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on enumeration concept

--- a/concepts/enumeration/introduction.md
+++ b/concepts/enumeration/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for enumeration concept

--- a/concepts/expressions/about.md
+++ b/concepts/expressions/about.md
@@ -1,3 +1,5 @@
+# About
+
 TODO: add information on expressions concept
 
 ## Quoting

--- a/concepts/expressions/introduction.md
+++ b/concepts/expressions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 All Common Lisp code is made of S-Expressions (Symbolic Expressions). They are called sexprs for short. Every sexpr is either an atom or a cons. When S-Expressions are evaluated, they automatically return some value which takes the place of the expression. When writing your own functions (using `defun`), the last value within the body of the `defun` is automatically returned:
 
 ```lisp

--- a/concepts/floating-point-numbers/about.md
+++ b/concepts/floating-point-numbers/about.md
@@ -1,3 +1,5 @@
+# About
+
 TODO: Add info about single and double-floats (as well as short and long?)
 
 Floating-Point Numbers are fractional or whole numbers including a decimal point (like `3.14`, `-1.7`, `99.99`, `2048.0`)

--- a/concepts/floating-point-numbers/introduction.md
+++ b/concepts/floating-point-numbers/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 Like many languages, Common Lisp contains floating point numbers. These are fractional or whole numbers including a decimal point (like `3.14`, `-1.7`, `99.99`, `2048.0`).

--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Common Lisp, global, named functions are defined with `defun`.
 
 This form takes as its first argument a list of parameters for the

--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 To define a global function in Common Lisp one uses the `defun`
 expression. This expression takes as its first argument a list of
 parameters (and empty list means the function has no parameters). This

--- a/concepts/hash-tables/about.md
+++ b/concepts/hash-tables/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on hash-tables concept

--- a/concepts/hash-tables/introduction.md
+++ b/concepts/hash-tables/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for hash-tables concept

--- a/concepts/higher-order-functions/about.md
+++ b/concepts/higher-order-functions/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on higher-order-functions concept

--- a/concepts/higher-order-functions/introduction.md
+++ b/concepts/higher-order-functions/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for higher-order-functions concept

--- a/concepts/integers/about.md
+++ b/concepts/integers/about.md
@@ -1,3 +1,5 @@
+# About
+
 TODO: Discuss fixnum and bignum, mention the size limits of fixnums (2^32, 2^64?)
 
 Integers are whole numbers without a decimal point (like `-6`, `0`, `25`, `1234`, etc.)

--- a/concepts/integers/introduction.md
+++ b/concepts/integers/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Like many languages Common Lisp contains integers. These are whole numbers without a decimal point (like `-6`, `0`, `25`, `1234`,
 etc.)
 

--- a/concepts/lambda-list/about.md
+++ b/concepts/lambda-list/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Common Lisp a parameter list (such as for defining a function) is also known as a (lambda list)[lambda-list]. Lambda lists are also used for defining macros and destructuring.
 
 Lambda lists can contain (lambda list keywords)[lambda-list-keyword] such as `&rest`, `&optional`, `&key` and others.

--- a/concepts/lambda-list/introduction.md
+++ b/concepts/lambda-list/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Common Lisp a function's argument list is known as a ('lambda list')[lambda-list]. A lambda list can can have arguments of different types. These different types are designated with the use of ('lambda list keywords')[lambda-list-keyword] which all begin with `&`. The most commonly used types are optional, keyword and rest arguments types. Every parameter in the lambda list after a particular lambda list keyword is will be of that type. A lambda list keyword can only be used once in a lambda list.
 
 Lambda lists are also used in other constructs which will be discussed later such as destructuring and macros.

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -1,3 +1,5 @@
+# About
+
 [Lists][hyper-cons-as-list] are a very common data type in Common Lisp. They are made up of a sequence of [cons][../cons/about.md] cells. Each `car` is an element of the list and every `cdr` is a either the next cons cell or a terminating atom.
 
 A list which terminates with the empty list is called a "proper list".

--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Given that the name of the language is Lisp which stands of _LISt Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
 
 While Common Lisp has other data structures as well as lists, lists are still heavily used.

--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -6,7 +6,7 @@ While Common Lisp has other data structures as well as lists, lists are still he
 
 A list in Common Lisp is a sequence of items. The items themselves do not have to be the same type. For example you can have a list of `1`, `two`, `"III"`.
 
-#### Creating Lists
+## Creating Lists
 
 One can simply type in a quoted list like this: `'(1 two "III")` and that will cause a list to be created and evaluated (it evaluates to: `(1 two "III")`.
 
@@ -30,7 +30,7 @@ There are also two main functions used to create lists: `list` and `cons`.
 
 (`first` and `rest` are synonyms of `car` and `cdr` and work exactly the same.)
 
-#### Length & Random Access
+## Length & Random Access
 
 The length of a list can be determined by the use of `length`. An empty list has length zero.
 

--- a/concepts/loop.basic/about.md
+++ b/concepts/loop.basic/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on loop.basic concept

--- a/concepts/loop.basic/introduction.md
+++ b/concepts/loop.basic/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for loop.basic concept

--- a/concepts/multiple-values/about.md
+++ b/concepts/multiple-values/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on multiple-values concept

--- a/concepts/multiple-values/introduction.md
+++ b/concepts/multiple-values/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for multiple-values concept

--- a/concepts/named-parameters/about.md
+++ b/concepts/named-parameters/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Common Lisp named parameters are called keyword parameters.
 
 Keyword parameters are designated by the `&key` lambda list keyword in a lambda list. Keyword parameters are not required, can have a default and also can specify a "supplied-p parameter" which will be "true" or "false" depending on whether an argument was provided for the parameter.

--- a/concepts/named-parameters/introduction.md
+++ b/concepts/named-parameters/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Common Lisp a function can have named parameters (referred to as "keyword parameters" or "keyword arguments"). These are designated in the lambda list by the `&key` lambda list keyword. Keyword parameters are not required parameters. Like optional parameters they can be given default values and symbols to bind to their 'supplied-or-not' state.
 
 When calling a function with keyword parameters the name of the parameter as a keyword is used in front of the parameter value. Keyword parameters can be specified by the caller of the function in any order.

--- a/concepts/nested-functions/about.md
+++ b/concepts/nested-functions/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on nested-functions concept

--- a/concepts/nested-functions/introduction.md
+++ b/concepts/nested-functions/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for nested-functions concept

--- a/concepts/packages/about.md
+++ b/concepts/packages/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on packages concept

--- a/concepts/packages/introduction.md
+++ b/concepts/packages/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for packages concept

--- a/concepts/printing/about.md
+++ b/concepts/printing/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on printing concept

--- a/concepts/printing/introduction.md
+++ b/concepts/printing/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for printing concept

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on recursion concept

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for recursion concept

--- a/concepts/rest-parameters/about.md
+++ b/concepts/rest-parameters/about.md
@@ -1,3 +1,5 @@
+# About
+
 A rest parameter is designated by the `&rest` lambda list keyword in a lambda list. This parameter will be bound to a value which is a list of all the arguments provided by the caller which is not consumed by other parameters.
 
 While multiple types of parameters can be combined with other types of parameters (optional and keyword arguments) this can be be problematic and should be done carefully. See the section on ("Mixing Different Parameter Types")(pcl-function) in Practical Common Lisp.

--- a/concepts/rest-parameters/introduction.md
+++ b/concepts/rest-parameters/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Common Lisp a function can have a parameter that will contain the "rest" of the arguments after any required or optional parameters are processed. This parameter is designated by the `&rest` lambda list keyword. If all arguments to a function are used by by other types of parameters then the rest parameter will be bound to an empty list. If there are unused arguments then the rest parameter will be bound to a list of those arguments.
 
 ```lisp

--- a/concepts/sameness/about.md
+++ b/concepts/sameness/about.md
@@ -4,7 +4,7 @@ Sameness is the concept about equality of things.
 
 Common Lisp, like other languages has a set of rules on how to decide if two objects are the 'same'. These rules define four levels, each with a function that performs that level of checking. The levels are ordered from strictest to loosest.
 
-### `eq`
+## `eq`
 
 The first level is object identity. This equality is checked with the function [`eq`][hyper-eq]. The two objects being checked for equality must be the very same object:
 
@@ -16,7 +16,7 @@ The first level is object identity. This equality is checked with the function [
 (let ((list1 '(a b c)) (list2 list1)) (eq list1 list2)) ; => T (these two lists are the same list)
 ```
 
-### `eql`
+## `eql`
 
 The second level adds equality of numbers and characters. This equality is checked with the function [`eql`][hyper-eql]. The way the checking is done depends upon the types of the arguments:
 
@@ -33,7 +33,7 @@ The second level adds equality of numbers and characters. This equality is check
 
 One may wonder why numbers and characters are not compared for object identity with [`eq`][hyper-eq]. The Common Lisp standard allows implementations to copy numbers and characters if they choose to do so. Thus `0` and `0` may not be [`eq`][hyper-eq] as they may be different instances of the number `0`.
 
-### `equal`
+## `equal`
 
 The third level checks for structural similarity. This equality is checked with [`equal`][hyper-equal]. The way the checking is done depends upon the types of the arguments:
 
@@ -53,7 +53,7 @@ The third level checks for structural similarity. This equality is checked with 
 (equal #P"foo/bar.md" #P"foo/bar.md") ; => T (pathnames are equal if "functionally equivalent"
 ```
 
-### `equalp`
+## `equalp`
 
 The fourth and most loose level of equality is checked with [`equalp`][hyper-equalp]. The how the checking is done depends upon the types:
 
@@ -73,7 +73,7 @@ The fourth and most loose level of equality is checked with [`equalp`][hyper-equ
 (equal #S(TEST :SLOT1 'a :SLOT2 'b) #S(TEST :SLOT1 'a :SLOT2 'b)) ; => T (structures of the same class with slots that have values which are `equalp`)
 ```
 
-### Type-specific functions
+## Type-specific functions
 
 The above are the 'generic' equality functions. They work, as defined, for any type. This can be useful when one writes generic code that does not know the types of objects it will be comparing until run-time. However it is generally considered "better style" to use type specific equality functions when one knows the types being compared. For example `string=` rather than `equal`. These functions will be presented and discussed in later concepts.
 

--- a/concepts/sameness/about.md
+++ b/concepts/sameness/about.md
@@ -1,3 +1,5 @@
+# About
+
 Sameness is the concept about equality of things.
 
 Common Lisp, like other languages has a set of rules on how to decide if two objects are the 'same'. These rules define four levels, each with a function that performs that level of checking. The levels are ordered from strictest to loosest.

--- a/concepts/sameness/introduction.md
+++ b/concepts/sameness/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Common Lisp has many different equality predicates. This differs from other programming languages which may have only one or two (perhaps `==` and `===` for example). Some of these predicates in Common Lisp are specific to types, while others are generic. It is these latter that this concept will cover.
 
 There are four generic equality predicates and they differ by their restrictiveness on what they consider "equal". They are, in order from most restrictive to least restrictive: `eq`, `eql`, `equal`, and `equalp`.

--- a/concepts/scope/about.md
+++ b/concepts/scope/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on scope concept

--- a/concepts/scope/introduction.md
+++ b/concepts/scope/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for scope concept

--- a/concepts/sets/about.md
+++ b/concepts/sets/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on sets concept

--- a/concepts/sets/introduction.md
+++ b/concepts/sets/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for sets concept

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on strings concept

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for strings concept

--- a/concepts/structures/about.md
+++ b/concepts/structures/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on structures concept

--- a/concepts/structures/introduction.md
+++ b/concepts/structures/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for structures concept

--- a/concepts/symbols/about.md
+++ b/concepts/symbols/about.md
@@ -1,4 +1,4 @@
-## Reference
+# Reference
 
 ```lisp
 ;; Returning a symbol from a `defun`

--- a/concepts/symbols/introduction.md
+++ b/concepts/symbols/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Symbols in Common Lisp are special values that can point to other values or, in the
 case of _keywords_, themselves. When symbols are evaluated by Lisp, they are
 replaced with the values they point to:

--- a/concepts/truthy-and-falsy/about.md
+++ b/concepts/truthy-and-falsy/about.md
@@ -1,3 +1,5 @@
+# About
+
 In Common Lisp, false values are represented by the empty list – `()` – or the
 symbol `nil`. These values can be quoted or unquoted.
 

--- a/concepts/truthy-and-falsy/introduction.md
+++ b/concepts/truthy-and-falsy/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 In Common Lisp all values are "true" except for `()` which is "false". There are two special constant symbols `t` and `nil` whose values are true and false respectively.

--- a/concepts/variables/about.md
+++ b/concepts/variables/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on variables concept

--- a/concepts/variables/introduction.md
+++ b/concepts/variables/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 TODO: add introduction for variables concept

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Common Lisp is an offshoot of the long-running family of Lisp programming languages. 
 It's a multi-paradigm programming language that allows you to choose the approach and paradigm according to your application domain.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 *What's needed*
 
 The basic items needed for developing in Common Lisp are:

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump
 into for those learning Common Lisp for the first time. These
 resources can help you get started:

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -3,7 +3,7 @@
 There are many more excellent resources, most of them crosslinked in
 one of the learning section.
 
-### Important resources
+## Important resources
 
 * [The Common Lisp HyperSpec](http://www.lispworks.com/documentation/common-lisp.html),
   by X3J13 committee. The Common Lisp Standard
@@ -15,7 +15,7 @@ one of the learning section.
   gateway
 * [The Common Lisp Wiki](http://www.cliki.net/)
 
-### Free books
+## Free books
 
 There are many other great books you can find links to. These are the
 most popularly linked introductory works.
@@ -41,7 +41,7 @@ helpful book, generally. If you find you prefer Scheme, it's an
 excellent start.
 
 
-### Quick reference
+## Quick reference
 
 Quick-guides / cheat sheets for Common Lisp:
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 There are many more excellent resources, most of them crosslinked in
 one of the learning section.
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Start up your Lisp implementation in the directory of the exercise you
 are working on (or change the current directory for an already running
 Lisp implementation to that directory).

--- a/exercises/concept/key-comparison/.docs/hints.md
+++ b/exercises/concept/key-comparison/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - Eli Bendersky has written [a good page][eli-lisp-equality] explaining the differences between the generic equality predicates in Common Lisp.

--- a/exercises/concept/key-comparison/.docs/instructions.md
+++ b/exercises/concept/key-comparison/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Leslie the Lisp Alien is programming their maze-robot (as young Lisp Aliens are wont to do) and needs some help. The maze consists of a series of rooms. Each room as a choices of doors. Each door needs a key. If you use the wrong key at a door it is likely to explode (do not worry for the robot, there will be no damage but buffing out the scorch marks is quite annoying for Leslie). If the robot doesn't have a key that opens any doors then the whole room will explode! (Again, do not worry it will not damage but will be annoying to clean.)
 
 What you need to help Leslie with is to give the robot the correct key for each room. The robot will use the key on each door in the room in order and go through the first door that opens.

--- a/exercises/concept/key-comparison/.docs/introduction.md
+++ b/exercises/concept/key-comparison/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Common Lisp has many different equality predicates. This differs from other programming languages which may have only one or two (perhaps `==` and `===` for example). Some of these predicates in Common Lisp are specific to types, while others are generic. It is these latter that this exercise will teach.
 
 There are four generic equality predicates and they differ by their restrictiveness on what they consider "equal". They are, in order from most restrictive to least restrictive: `eq`, `eql`, `equal`, and `equalp`.

--- a/exercises/concept/key-comparison/.meta/design.md
+++ b/exercises/concept/key-comparison/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Be familiar with `eq`, `eql`, `equal` and `equalp` and how each builds upon the previous.

--- a/exercises/concept/leslies-lists/.docs/hints.md
+++ b/exercises/concept/leslies-lists/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Making a new list
 
 - Common Lisp has a [rather descriptively named function][hyper-list] for making a _LIST_.

--- a/exercises/concept/leslies-lists/.docs/instructions.md
+++ b/exercises/concept/leslies-lists/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Leslie the Lisp Alien needs to do some shopping. It is very important to have a shopping list. One needs to add things to it, and remove things from it.
 
 Of course simple pen and paper will not do for a Lisp Alien. "List" is most of the word "Lisp" even!. There must be some functions written to help keep track of the shopping.

--- a/exercises/concept/leslies-lists/.docs/introduction.md
+++ b/exercises/concept/leslies-lists/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 Given that the name of the language is Lisp which stands of _LISt Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
 
 While Common Lisp has other data structures as well as lists, lists are still heavily used.

--- a/exercises/concept/leslies-lists/.docs/introduction.md
+++ b/exercises/concept/leslies-lists/.docs/introduction.md
@@ -6,7 +6,7 @@ While Common Lisp has other data structures as well as lists, lists are still he
 
 A list in Common Lisp is a sequence of items. The items themselves do not have to be the same type. For example you can have a list of `1`, `two`, `"III"`.
 
-#### Creating Lists
+## Creating Lists
 
 One can simply type in a quoted list like this: `'(1 two "III")` and that will cause a list to be created and evaluated (it evaluates to: `(1 two "III")`.
 
@@ -30,7 +30,7 @@ There are also two main functions used to create lists: `list` and `cons`.
 
 (`first` and `rest` are synonyms of `car` and `cdr` and work exactly the same.)
 
-#### Length & Random Access
+## Length & Random Access
 
 The length of a list can be determined by the use of `length`. An empty list has length zero.
 

--- a/exercises/concept/leslies-lists/.meta/design.md
+++ b/exercises/concept/leslies-lists/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 This issue describes how to implement the `lists` concept exercise for the Common Lisp track.
 
 ## Getting started

--- a/exercises/concept/lillys-lasagna-leftovers/.docs/hints.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Make `preparation-time-in-minutes` easier to use
 
     - A "rest parameter" will collect all arguments not consumed by other parameters into a list.

--- a/exercises/concept/lillys-lasagna-leftovers/.docs/instructions.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Lilly the Lisp Alien has definitely made a lot of Lasagna with your
 help. They want to thank you by giving you some leftovers. But first
 they have some feedback about one of the functions you helped them

--- a/exercises/concept/lillys-lasagna-leftovers/.docs/introduction.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Common Lisp a functions argument list (also known as a ('lambda list')[lambda-list]) can have arguments of different types. These different types are designated with the use of ("lambda list keywords")[lambda-list-keyword] which all begin with `&`. The most commonly used types are optional, keyword and rest arguments types. Every parameter in the lambda list after a particular lambda list keyword is will be of that type. A lambda list keyword can only be used once in a lambda list.
 
 ## default-parameters

--- a/exercises/concept/lillys-lasagna-leftovers/.meta/design.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 This exercise should focus on teaching about the special types of arguments to `defun`: `&key`, `&rest`, `&optional`.

--- a/exercises/concept/lillys-lasagna/.docs/hints.md
+++ b/exercises/concept/lillys-lasagna/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Define the expected oven time in minutes
 
 - A global, named function is defined with

--- a/exercises/concept/lillys-lasagna/.docs/instructions.md
+++ b/exercises/concept/lillys-lasagna/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Lilly the Lisp Alien is back and doing more cooking! This time they
 are going to create Lisp Alien Lasagna which is not entirely unlike
 Human Lasagna.

--- a/exercises/concept/lillys-lasagna/.docs/introduction.md
+++ b/exercises/concept/lillys-lasagna/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 To define a global function in Common Lisp one uses the `defun`
 expression. This expression takes as its first argument a list of
 parameters (and empty list means the function has no parameters). This

--- a/exercises/concept/lillys-lasagna/.meta/design.md
+++ b/exercises/concept/lillys-lasagna/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 This exercise should focus on teaching `defun` The student should be comfortable defining top-level functions. They should also be introduced to the usage of docstrings.

--- a/exercises/concept/pal-picker/.docs/hints.md
+++ b/exercises/concept/pal-picker/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - If you're not sure where to start, try counting the number of "branches" that

--- a/exercises/concept/pal-picker/.docs/instructions.md
+++ b/exercises/concept/pal-picker/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 When the Lisp aliens first came to Earth, they encountered countless weird and
 wonderful things, but one of their favorite discoveries was that of
 "pets". Let's be honest, what sort of alien wouldn't gush over a puppy or

--- a/exercises/concept/pal-picker/.docs/introduction.md
+++ b/exercises/concept/pal-picker/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Truthy And Falsy
 
 In Common Lisp all values are "true" except for `()` which is "false". There are two special constant symbols `t` and `nil` whose values are true and false respectively.

--- a/exercises/concept/pal-picker/.meta/design.md
+++ b/exercises/concept/pal-picker/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how to use `when` and `unless` for single-branch conditions

--- a/exercises/concept/pizza-pi/.docs/approaches.md
+++ b/exercises/concept/pizza-pi/.docs/approaches.md
@@ -1,6 +1,6 @@
 # Approaches
 
-### A More Idiomatic Approach
+## A More Idiomatic Approach
 
 While this exercise encouraged the use of `=` in solving the final task (in order to introduce the comparison operators), the standard provides a number of predicates that can replace the expression you wrote with `mod` and `=`. The equation from the final task might be more idiomatically written as:
 

--- a/exercises/concept/pizza-pi/.docs/approaches.md
+++ b/exercises/concept/pizza-pi/.docs/approaches.md
@@ -1,3 +1,5 @@
+# Approaches
+
 ### A More Idiomatic Approach
 
 While this exercise encouraged the use of `=` in solving the final task (in order to introduce the comparison operators), the standard provides a number of predicates that can replace the expression you wrote with `mod` and `=`. The equation from the final task might be more idiomatically written as:

--- a/exercises/concept/pizza-pi/.docs/hints.md
+++ b/exercises/concept/pizza-pi/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - It might be useful to have a list of all of the numeric operations in Lisp –

--- a/exercises/concept/pizza-pi/.docs/instructions.md
+++ b/exercises/concept/pizza-pi/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 Lilly, a culinarily-inclined Lisp Alien, wants to throw a pizza party for
 themselves and some friends but, wanting to make the most of their ingredients, would
 like to know exactly how much of each component they'll need before starting.

--- a/exercises/concept/pizza-pi/.docs/introduction.md
+++ b/exercises/concept/pizza-pi/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 In Common Lisp, like many languages, numbers come in a few of types – two of the most basic are:
 
 ## Integers

--- a/exercises/concept/pizza-pi/.meta/design.md
+++ b/exercises/concept/pizza-pi/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how to write integer and floating point literals

--- a/exercises/concept/socks-and-sexprs/.docs/hints.md
+++ b/exercises/concept/socks-and-sexprs/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## 1. Refresh Lenny on symbols
 
 - If you are having trouble returning a symbol from a function, you might need

--- a/exercises/concept/socks-and-sexprs/.docs/instructions.md
+++ b/exercises/concept/socks-and-sexprs/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 You! Yes you, brave lisper! [Lenny the lisp alien][alien] needs your help! Lenny
 wants to go hang out with all the other lisp aliens, but their parents have told Lenny
 that they're not going anywhere until their room is clean.

--- a/exercises/concept/socks-and-sexprs/.docs/introduction.md
+++ b/exercises/concept/socks-and-sexprs/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ## Comments
 
 Common Lisp allows the programmer to write "comments" that are ignored by the

--- a/exercises/concept/socks-and-sexprs/.meta/design.md
+++ b/exercises/concept/socks-and-sexprs/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 This document describes how to implement the `basics` concept exercise for the
 Common Lisp track.
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
