### PR TITLE
Practice update/hello world

### DIFF
--- a/config.json
+++ b/config.json
@@ -367,7 +367,7 @@
         "topics": [
           "strings"
         ],
-        "status": "wip"
+        "status": "beta"
       },
       {
         "slug": "two-fer",

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "v2": true,
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
   "source": "This is an exercise to introduce users to using Exercism",
   "files": {

--- a/exercises/practice/hello-world/.meta/example.lisp
+++ b/exercises/practice/hello-world/.meta/example.lisp
@@ -1,7 +1,7 @@
-(defpackage #:hello-world
-  (:use #:common-lisp)
-  (:export #:hello))
+(defpackage :hello-world
+  (:use :cl)
+  (:export :hello))
 
-(in-package #:hello-world)
+(in-package :hello-world)
 
 (defun hello () "Hello, World!")

--- a/exercises/practice/hello-world/hello-world-test.lisp
+++ b/exercises/practice/hello-world/hello-world-test.lisp
@@ -1,20 +1,27 @@
-;;; 
-;;; hello-world v1.1.0
-;;; 
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "hello-world")
+;; Ensures that key-comparison.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "hello-world")
+  (ql:quickload :fiveam))
 
-(defpackage #:hello-world-test
-  (:use #:common-lisp #:lisp-unit))
-(in-package #:hello-world-test)
+;; Defines the testing package with FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :hello-world-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
 
-(define-test
-  say-hi!
-  (assert-equal
-    "Hello, World!"
-    (hello-world:hello)))
+;; Enter the testing package
+(in-package :hello-world-test)
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+;; Define and enter a new FiveAM test-suite
+(def-suite hello-world-suite)
+(in-suite hello-world-suite)
+
+(test say-hi
+      (is (string= "Hello, World!" (hello-world:hello))))
+
+;; Either provides human-readable results to the user or machine-readable
+;; results to the test runner. The default upon calling `(run-tests)` is to
+;; explain the results in a human-readable way
+(defun run-tests (&optional (explain t))
+  (let ((tests (run 'hello-world-suite))) ; Run the tests once
+    (if explain (explain! tests) tests))) ; Optionally explain the results

--- a/exercises/practice/hello-world/hello-world.lisp
+++ b/exercises/practice/hello-world/hello-world.lisp
@@ -1,8 +1,6 @@
-(in-package #:cl-user)
-(defpackage #:hello-world
-  (:use #:cl)
-  (:export #:hello))
-(in-package #:hello-world)
+(defpackage :hello-world
+  (:use :cl)
+  (:export :hello))
+(in-package :hello-world)
 
 (defun hello NIL)
-

--- a/src/test-exercises/run.lisp
+++ b/src/test-exercises/run.lisp
@@ -3,11 +3,14 @@
 ;; for v2 test running
 (pushnew :xlisp-test *features*)
 
+(defun example-files (data)
+  (or (aget :exemplar (aget :files data))
+      (aget :example (aget :files data))))
+
 (defun test-v2-exercise (data)
   (let ((test-files (aget :test (aget :files data)))
         (solution-files (aget :solution (aget :files data)))
-        (exemplar-files (or (aget :exemplar (aget :files data))
-                            (aget :example (aget :files data)))))
+        (exemplar-files (example-files data)))
     (unwind-protect
          (progn
            (dolist (f (append solution-files exemplar-files test-files))
@@ -20,8 +23,7 @@
 
 (defun test-v3-exercise (data)
   (let ((test-files (aget :test (aget :files data)))
-        (exemplar-files (aget :exemplar (aget :files data))))
-
+        (exemplar-files (example-files data)))
     (unwind-protect
          (progn
            (dolist (f (append test-files exemplar-files))


### PR DESCRIPTION
This PR updates the hello-world practice exercise to v3.

Along the way I found out that the CI system assumed `exemplar` files and couldn't handle the practice exercise `example` file config key (this had been adjusted for v2 tests - seem to have overlooked doing this for v3 tests.

(ref: #347)