### PR TITLE
Update practice exercises

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://github.com/monkbroc",
-  "source": "Julien Vanier",
-  "files": {
-    "test": [
+  "source_url":"https://github.com/monkbroc",
+  "source":"Julien Vanier",
+  "files":{
+    "test":[
       "acronym-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "acronym.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/acronym/acronym-test.lisp
+++ b/exercises/practice/acronym/acronym-test.lisp
@@ -1,43 +1,35 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "acronym")
+;; Ensures that acronym.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "acronym")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from acronym and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:acronym-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:acronym-test)
 
+;; Define and enter a new FiveAM test-suite
+(def-suite* acronym-suite)
 
-(define-test empty-gives-empty
-  (assert-equal
-    ""
-    (acronym:acronym "")))
+(test empty-gives-empty (is (equal "" (acronym:acronym ""))))
 
-(define-test png-test
-  (assert-equal
-    "PNG"
-    (acronym:acronym "Portable Network Graphics")))
+(test png-test (is (equal "PNG" (acronym:acronym "Portable Network Graphics"))))
 
-(define-test ror-test
-  (assert-equal
-    "ROR"
-    (acronym:acronym "Ruby on Rails")))
+(test ror-test (is (equal "ROR" (acronym:acronym "Ruby on Rails"))))
 
-(define-test fifo-test
-  (assert-equal
-    "FIFO"
-    (acronym:acronym "First In, First Out")))
+(test fifo-test (is (equal "FIFO" (acronym:acronym "First In, First Out"))))
 
-(define-test php-test
-  (assert-equal
-    "PHP"
-    (acronym:acronym "PHP: Hypertext Preprocessor")))
+(test php-test
+ (is (equal "PHP" (acronym:acronym "PHP: Hypertext Preprocessor"))))
 
-(define-test cmos-test
-  (assert-equal
-    "CMOS"
-    (acronym:acronym "Complementary metal-oxide semiconductor")))
+(test cmos-test
+ (is
+  (equal "CMOS" (acronym:acronym "Complementary metal-oxide semiconductor"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :acronym-test))
+(defun run-tests (&optional (test-or-suite 'acronym-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/acronym/acronym.lisp
+++ b/exercises/practice/acronym/acronym.lisp
@@ -1,5 +1,5 @@
 (defpackage #:acronym
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:acronym))
 
 (in-package #:acronym)

--- a/exercises/practice/acronym/acronym.lisp
+++ b/exercises/practice/acronym/acronym.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:acronym
   (:use #:common-lisp)
   (:export #:acronym))

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,15 +1,14 @@
 {
-  "v2": true,
-  "files": {
-    "test": [
+  "files":{
+    "test":[
       "all-your-base-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "all-your-base.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/all-your-base/all-your-base-test.lisp
+++ b/exercises/practice/all-your-base/all-your-base-test.lisp
@@ -1,88 +1,71 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "all-your-base")
+;; Ensures that all-your-base.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "all-your-base")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from all-your-base and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:all-your-base-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:all-your-base-test)
 
-(define-test single-bit-one-to-decimal
-  (assert-equal '( 1 )
-                (all-your-base:rebase '( 1 ) 2 10)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* all-your-base-suite)
 
-(define-test binary-to-single-decimal
-  (assert-equal '( 5 )
-                (all-your-base:rebase '( 1 0 1 ) 2 10)))
+(test single-bit-one-to-decimal
+ (is (equal '(1) (all-your-base:rebase '(1) 2 10))))
 
-(define-test single-decimal-to-binary
-  (assert-equal '( 1 0 1 )
-                (all-your-base:rebase '( 5 ) 10 2)))
+(test binary-to-single-decimal
+ (is (equal '(5) (all-your-base:rebase '(1 0 1) 2 10))))
 
-(define-test binary-to-multiple-decimal
-  (assert-equal '( 4 2 )
-                (all-your-base:rebase '( 1 0 1 0 1 0 ) 2 10)))
+(test single-decimal-to-binary
+ (is (equal '(1 0 1) (all-your-base:rebase '(5) 10 2))))
 
-(define-test decimal-to-binary
-  (assert-equal '( 1 0 1 0 1 0 )
-                (all-your-base:rebase '( 4 2 ) 10 2)))
+(test binary-to-multiple-decimal
+ (is (equal '(4 2) (all-your-base:rebase '(1 0 1 0 1 0) 2 10))))
 
-(define-test trinary-to-hexadecimal
-  (assert-equal '( 2 10 )
-                (all-your-base:rebase '( 1 1 2 0 ) 3 16)))
+(test decimal-to-binary
+ (is (equal '(1 0 1 0 1 0) (all-your-base:rebase '(4 2) 10 2))))
 
-(define-test hexadecimal-to-trinary
-  (assert-equal '( 1 1 2 0 )
-                (all-your-base:rebase '( 2 10 ) 16 3)))
+(test trinary-to-hexadecimal
+ (is (equal '(2 10) (all-your-base:rebase '(1 1 2 0) 3 16))))
 
-(define-test number-15-bit-integer
-  (assert-equal '( 6 10 45 )
-                (all-your-base:rebase '( 3 46 60 ) 97 73)))
+(test hexadecimal-to-trinary
+ (is (equal '(1 1 2 0) (all-your-base:rebase '(2 10) 16 3))))
 
-(define-test empty-list
-  (assert-equal '( 0 )
-                (all-your-base:rebase '() 2 10)))
+(test number-15-bit-integer
+ (is (equal '(6 10 45) (all-your-base:rebase '(3 46 60) 97 73))))
 
-(define-test single-zero
-  (assert-equal '( 0 )
-                (all-your-base:rebase '( 0 ) 10 2)))
+(test empty-list (is (equal '(0) (all-your-base:rebase 'nil 2 10))))
 
-(define-test multiple-zeros
-  (assert-equal '( 0 )
-                (all-your-base:rebase '( 0 0 0 ) 10 2)))
+(test single-zero (is (equal '(0) (all-your-base:rebase '(0) 10 2))))
 
-(define-test leading-zeros
-  (assert-equal '( 4 2 )
-                (all-your-base:rebase '( 0 6 0 ) 7 10)))
+(test multiple-zeros (is (equal '(0) (all-your-base:rebase '(0 0 0) 10 2))))
 
-(define-test input-base-is-one
-  (assert-false (all-your-base:rebase '( 0 ) 1 10)))
+(test leading-zeros (is (equal '(4 2) (all-your-base:rebase '(0 6 0) 7 10))))
 
-(define-test input-base-is-zero
-  (assert-false (all-your-base:rebase '() 0 10)))
+(test input-base-is-one (is (not (all-your-base:rebase '(0) 1 10))))
 
-(define-test input-base-is-negative
-  (assert-false (all-your-base:rebase '( 1 ) -2 10)))
+(test input-base-is-zero (is (not (all-your-base:rebase 'nil 0 10))))
 
-(define-test negative-digit
-  (assert-false (all-your-base:rebase '( 1 -1 1 0 1 0 ) 2 10)))
+(test input-base-is-negative (is (not (all-your-base:rebase '(1) -2 10))))
 
-(define-test invalid-positive-digit
-  (assert-false (all-your-base:rebase '( 1 2 1 0 1 0 ) 2 10)))
+(test negative-digit (is (not (all-your-base:rebase '(1 -1 1 0 1 0) 2 10))))
 
-(define-test output-base-is-one
-  (assert-false (all-your-base:rebase '( 1 0 1 0 1 0 ) 2 1)))
+(test invalid-positive-digit
+ (is (not (all-your-base:rebase '(1 2 1 0 1 0) 2 10))))
 
-(define-test output-base-is-zero
-  (assert-false (all-your-base:rebase '( 7 ) 10 0)))
+(test output-base-is-one (is (not (all-your-base:rebase '(1 0 1 0 1 0) 2 1))))
 
-(define-test output-base-is-negative
-  (assert-false (all-your-base:rebase '( 1 ) 2 -7)))
+(test output-base-is-zero (is (not (all-your-base:rebase '(7) 10 0))))
 
-(define-test both-bases-are-negative
-  (assert-false (all-your-base:rebase '( 1 ) -2 -7)))
+(test output-base-is-negative (is (not (all-your-base:rebase '(1) 2 -7))))
 
+(test both-bases-are-negative (is (not (all-your-base:rebase '(1) -2 -7))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :all-your-base-test))
+(defun run-tests (&optional (test-or-suite 'all-your-base-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/all-your-base/all-your-base.lisp
+++ b/exercises/practice/all-your-base/all-your-base.lisp
@@ -1,5 +1,5 @@
 (defpackage #:all-your-base
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:rebase))
 
 (in-package #:all-your-base)

--- a/exercises/practice/all-your-base/all-your-base.lisp
+++ b/exercises/practice/all-your-base/all-your-base.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:all-your-base
   (:use #:common-lisp)
   (:export #:rebase))

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://jumpstartlab.com",
-  "source": "Jumpstart Lab Warm-up",
-  "files": {
-    "test": [
+  "source_url":"http://jumpstartlab.com",
+  "source":"Jumpstart Lab Warm-up",
+  "files":{
+    "test":[
       "allergies-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "allergies.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/allergies/allergies-test.lisp
+++ b/exercises/practice/allergies/allergies-test.lisp
@@ -1,61 +1,65 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "allergies")
+;; Ensures that allergies.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "allergies")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from allergies and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:allergies-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:allergies-test)
 
-(define-test no-allergies-at-all
-  (assert-equalp '() (allergies:list 0)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* allergies-suite)
 
-(define-test allergic-to-just-eggs
-  (assert-equalp '("eggs") (allergies:list 1)))
+(test no-allergies-at-all (is (equalp 'nil (allergies:list 0))))
 
-(define-test allergic-to-just-peanuts
-  (assert-equalp '("peanuts") (allergies:list 2)))
+(test allergic-to-just-eggs (is (equalp '("eggs") (allergies:list 1))))
 
-(define-test allergic-to-just-strawberries
-  (assert-equalp '("strawberries") (allergies:list 8)))
+(test allergic-to-just-peanuts (is (equalp '("peanuts") (allergies:list 2))))
 
-(define-test allergic-to-eggs-and-peanuts
-  (assert-equalp '("eggs" "peanuts") (allergies:list 3)))
+(test allergic-to-just-strawberries
+ (is (equalp '("strawberries") (allergies:list 8))))
 
-(define-test allergic-to-more-than-eggs-but-not-peanuts
-  (assert-equalp '("eggs" "shellfish") (allergies:list 5)))
+(test allergic-to-eggs-and-peanuts
+ (is (equalp '("eggs" "peanuts") (allergies:list 3))))
 
-(define-test allergic-to-lots-of-stuff
-  (assert-equalp
-   '("strawberries" "tomatoes" "chocolate" "pollen" "cats")
-   (allergies:list 248)))
+(test allergic-to-more-than-eggs-but-not-peanuts
+ (is (equalp '("eggs" "shellfish") (allergies:list 5))))
 
-(define-test allergic-to-everything
-  (assert-equalp
-   '("eggs" "peanuts" "shellfish" "strawberries" "tomatoes"
-     "chocolate" "pollen" "cats")
-   (allergies:list 255)))
+(test allergic-to-lots-of-stuff
+ (is
+  (equalp '("strawberries" "tomatoes" "chocolate" "pollen" "cats")
+          (allergies:list 248))))
 
-(define-test no-allergies-means-not-allergic
-  (assert-false (allergies:allergic-to-p 0 "peanuts"))
-  (assert-false (allergies:allergic-to-p 0 "cats"))
-  (assert-false (allergies:allergic-to-p 0 "strawberries")))
+(test allergic-to-everything
+ (is
+  (equalp
+   '("eggs" "peanuts" "shellfish" "strawberries" "tomatoes" "chocolate"
+     "pollen" "cats")
+   (allergies:list 255))))
 
-(define-test is-allergic-to-eggs
-  (assert-true (allergies:allergic-to-p 1 "eggs")))
+(test no-allergies-means-not-allergic
+ (is (not (allergies:allergic-to-p 0 "peanuts")))
+ (is (not (allergies:allergic-to-p 0 "cats")))
+ (is (not (allergies:allergic-to-p 0 "strawberries"))))
 
-(define-test allergic-to-eggs-in-addition-to-other-stuff
-  (assert-true (allergies:allergic-to-p 5 "eggs")))
+(test is-allergic-to-eggs (is (allergies:allergic-to-p 1 "eggs")))
 
-(define-test case-insensitive
-  (assert-true (allergies:allergic-to-p 1 "EGGS")))
+(test allergic-to-eggs-in-addition-to-other-stuff
+ (is (allergies:allergic-to-p 5 "eggs")))
 
-(define-test ignore-non-allergen-score-parts
-  (assert-equalp
-   '("eggs" "shellfish" "strawberries" "tomatoes" "chocolate" "pollen"
-     "cats")
-   (allergies:list 509)))
+(test case-insensitive (is (allergies:allergic-to-p 1 "EGGS")))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :allergies-test))
+(test ignore-non-allergen-score-parts
+ (is
+  (equalp
+   '("eggs" "shellfish" "strawberries" "tomatoes" "chocolate" "pollen" "cats")
+   (allergies:list 509))))
+
+(defun run-tests (&optional (test-or-suite 'allergies-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/allergies/allergies.lisp
+++ b/exercises/practice/allergies/allergies.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:allergies
   (:use #:common-lisp)
   (:shadow #:list)

--- a/exercises/practice/allergies/allergies.lisp
+++ b/exercises/practice/allergies/allergies.lisp
@@ -1,5 +1,5 @@
 (defpackage #:allergies
-  (:use #:common-lisp)
+  (:use #:cl)
   (:shadow #:list)
   (:export #:allergic-to-p #:list))
 

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://github.com/rchatley/extreme_startup",
-  "source": "Inspired by the Extreme Startup game",
-  "files": {
-    "test": [
+  "source_url":"https://github.com/rchatley/extreme_startup",
+  "source":"Inspired by the Extreme Startup game",
+  "files":{
+    "test":[
       "anagram-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "anagram.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/anagram/anagram-test.lisp
+++ b/exercises/practice/anagram/anagram-test.lisp
@@ -1,54 +1,59 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "anagram")
+;; Ensures that anagram.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "anagram")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from anagram and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:anagram-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:anagram-test)
 
-(define-test no-matches
-  (assert-equal '()
-      (anagram:anagrams-for
-       "diaper"
-       '("hello" "world" "zombies" "pants"))))
+;; Define and enter a new FiveAM test-suite
+(def-suite* anagram-suite)
 
-(define-test detect-simple-anagram
-  (assert-equal '("tan")
-      (anagram:anagrams-for "ant" '("tan" "stand" "at"))))
+(test no-matches
+ (is
+  (equal 'nil
+         (anagram:anagrams-for "diaper" '("hello" "world" "zombies" "pants")))))
 
-(define-test does-not-confuse-different-duplicates
-  (assert-equal '() (anagram:anagrams-for "galea" '("eagle"))))
+(test detect-simple-anagram
+ (is (equal '("tan") (anagram:anagrams-for "ant" '("tan" "stand" "at")))))
 
-(define-test eliminate-anagram-subsets
-  (assert-equal '() (anagram:anagrams-for "good" '("dog" "goody"))))
+(test does-not-confuse-different-duplicates
+ (is (equal 'nil (anagram:anagrams-for "galea" '("eagle")))))
 
-(define-test detect-anagram
-  (assert-equal '("inlets")
-      (anagram:anagrams-for
-       "listen"
-       '("enlists" "google" "inlets" "banana"))))
+(test eliminate-anagram-subsets
+ (is (equal 'nil (anagram:anagrams-for "good" '("dog" "goody")))))
 
-(define-test multiple-anagrams
-  (assert-equal '("gallery" "regally" "largely")
-      (anagram:anagrams-for
-       "allergy"
-       '("gallery" "ballerina" "regally" "clergy" "largely" "leading"))))
+(test detect-anagram
+ (is
+  (equal '("inlets")
+         (anagram:anagrams-for "listen"
+                               '("enlists" "google" "inlets" "banana")))))
 
-(define-test case-insensitive-anagrams
-  (assert-equal '("Carthorse")
-      (anagram:anagrams-for
-       "Orchestra"
-       '("cashregister" "Carthorse" "radishes"))))
+(test multiple-anagrams
+ (is
+  (equal '("gallery" "regally" "largely")
+         (anagram:anagrams-for "allergy"
+                               '("gallery" "ballerina" "regally" "clergy"
+                                 "largely" "leading")))))
 
-(define-test word-is-not-own-anagram
-  (assert-equal '()
-      (anagram:anagrams-for "banana" '("banana"))))
+(test case-insensitive-anagrams
+ (is
+  (equal '("Carthorse")
+         (anagram:anagrams-for "Orchestra"
+                               '("cashregister" "Carthorse" "radishes")))))
 
-(define-test word-is-not-own-anagram-case-insensitively
-  (assert-equal '()
-      (anagram:anagrams-for "bananarama" '("BananaRama"))))
+(test word-is-not-own-anagram
+ (is (equal 'nil (anagram:anagrams-for "banana" '("banana")))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :anagram-test))
+(test word-is-not-own-anagram-case-insensitively
+ (is (equal 'nil (anagram:anagrams-for "bananarama" '("BananaRama")))))
+
+(defun run-tests (&optional (test-or-suite 'anagram-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/anagram/anagram.lisp
+++ b/exercises/practice/anagram/anagram.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:anagram
   (:use #:common-lisp)
   (:export #:anagrams-for))

--- a/exercises/practice/anagram/anagram.lisp
+++ b/exercises/practice/anagram/anagram.lisp
@@ -1,5 +1,5 @@
 (defpackage #:anagram
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:anagrams-for))
 
 (in-package #:anagram)

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number",
-  "source": "Wikipedia",
-  "files": {
-    "test": [
+  "source_url":"https://en.wikipedia.org/wiki/Narcissistic_number",
+  "source":"Wikipedia",
+  "files":{
+    "test":[
       "armstrong-numbers-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "armstrong-numbers.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-test.lisp
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-test.lisp
@@ -1,69 +1,44 @@
-;;;
-;;; armstrong-numbers v1.0.0
-;;;
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "armstrong-numbers")
+;; Ensures that armstrong-numbers.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "armstrong-numbers")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from armstrong-numbers and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:armstrong-numbers-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
+
+;; Enter the testing package
 (in-package #:armstrong-numbers-test)
 
-(define-test
-  single-digit-numbers-are-armstrong-numbers
-  (assert-equal
-    T
-    (armstrong-numbers:armstrong-number-p 5)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* armstrong-numbers-suite)
 
+(test single-digit-numbers-are-armstrong-numbers
+ (is (equal t (armstrong-numbers:armstrong-number-p 5))))
 
-(define-test
-  there-are-no-2-digit-armstrong-numbers
-  (assert-equal
-    'NIL
-    (armstrong-numbers:armstrong-number-p 10)))
+(test there-are-no-2-digit-armstrong-numbers
+ (is (equal 'nil (armstrong-numbers:armstrong-number-p 10))))
 
+(test three-digit-number-that-is-an-armstrong-number
+ (is (equal t (armstrong-numbers:armstrong-number-p 153))))
 
-(define-test
-  three-digit-number-that-is-an-armstrong-number
-  (assert-equal
-    T
-    (armstrong-numbers:armstrong-number-p 153)))
+(test three-digit-number-that-is-not-an-armstrong-number
+ (is (equal 'nil (armstrong-numbers:armstrong-number-p 100))))
 
+(test four-digit-number-that-is-an-armstrong-number
+ (is (equal t (armstrong-numbers:armstrong-number-p 9474))))
 
-(define-test
-  three-digit-number-that-is-not-an-armstrong-number
-  (assert-equal
-    'NIL
-    (armstrong-numbers:armstrong-number-p 100)))
+(test four-digit-number-that-is-not-an-armstrong-number
+ (is (equal 'nil (armstrong-numbers:armstrong-number-p 9475))))
 
+(test seven-digit-number-that-is-an-armstrong-number
+ (is (equal t (armstrong-numbers:armstrong-number-p 9926315))))
 
-(define-test
-  four-digit-number-that-is-an-armstrong-number
-  (assert-equal
-    T
-    (armstrong-numbers:armstrong-number-p 9474)))
+(test seven-digit-number-that-is-not-an-armstrong-number
+ (is (equal 'nil (armstrong-numbers:armstrong-number-p 9926314))))
 
-
-(define-test
-  four-digit-number-that-is-not-an-armstrong-number
-  (assert-equal
-    'NIL
-    (armstrong-numbers:armstrong-number-p 9475)))
-
-
-(define-test
-  seven-digit-number-that-is-an-armstrong-number
-  (assert-equal
-    T
-    (armstrong-numbers:armstrong-number-p 9926315)))
-
-
-(define-test
-  seven-digit-number-that-is-not-an-armstrong-number
-  (assert-equal
-    'NIL
-    (armstrong-numbers:armstrong-number-p 9926314)))
-
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(defun run-tests (&optional (test-or-suite 'armstrong-numbers-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.lisp
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:armstrong-numbers
   (:use #:cl)
   (:export #:armstrong-number-p))

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://en.wikipedia.org/wiki/Atbash",
-  "source": "Wikipedia",
-  "files": {
-    "test": [
+  "source_url":"http://en.wikipedia.org/wiki/Atbash",
+  "source":"Wikipedia",
+  "files":{
+    "test":[
       "atbash-cipher-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "atbash-cipher.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/atbash-cipher/atbash-cipher-test.lisp
+++ b/exercises/practice/atbash-cipher/atbash-cipher-test.lisp
@@ -1,41 +1,44 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "atbash-cipher")
+;; Ensures that atbash-cipher.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "atbash-cipher")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from atbash-cipher and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:atbash-cipher-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:atbash-cipher-test)
 
-(define-test encode-no
-  (assert-equal "ml" (atbash-cipher:encode "no")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* atbash-cipher-suite)
 
-(define-test encode-yes
-  (assert-equal "bvh" (atbash-cipher:encode "yes")))
+(test encode-no (is (equal "ml" (atbash-cipher:encode "no"))))
 
-(define-test encode-OMG
-  (assert-equal "lnt" (atbash-cipher:encode "OMG")))
+(test encode-yes (is (equal "bvh" (atbash-cipher:encode "yes"))))
 
-(define-test encode-O-M-G
-  (assert-equal "lnt" (atbash-cipher:encode "O M G")))
+(test encode-omg (is (equal "lnt" (atbash-cipher:encode "OMG"))))
 
-(define-test encode-long-word
-  (assert-equal "nrmwy oldrm tob"
-                (atbash-cipher:encode "mindblowingly")))
+(test encode-o-m-g (is (equal "lnt" (atbash-cipher:encode "O M G"))))
 
-(define-test encode-numbers
-  (assert-equal "gvhgr mt123 gvhgr mt"
-                (atbash-cipher:encode "Testing, 1 2 3, testing.")))
+(test encode-long-word
+ (is (equal "nrmwy oldrm tob" (atbash-cipher:encode "mindblowingly"))))
 
-(define-test encode-sentence
-  (assert-equal "gifgs rhurx grlm"
-                (atbash-cipher:encode "Truth is fiction.")))
+(test encode-numbers
+ (is
+  (equal "gvhgr mt123 gvhgr mt"
+         (atbash-cipher:encode "Testing, 1 2 3, testing."))))
 
-(define-test encode-all-the-things
-  (let ((plaintext "The quick brown fox jumps over the lazy dog.")
-        (cipher "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"))
-    (assert-equal cipher (atbash-cipher:encode plaintext))))
+(test encode-sentence
+ (is (equal "gifgs rhurx grlm" (atbash-cipher:encode "Truth is fiction."))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :atbash-cipher-test))
+(test encode-all-the-things
+ (let ((plaintext "The quick brown fox jumps over the lazy dog.")
+       (cipher "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"))
+   (is (equal cipher (atbash-cipher:encode plaintext)))))
+
+(defun run-tests (&optional (test-or-suite 'atbash-cipher-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/atbash-cipher/atbash-cipher.lisp
+++ b/exercises/practice/atbash-cipher/atbash-cipher.lisp
@@ -1,5 +1,5 @@
 (defpackage #:atbash-cipher
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:encode))
 
 (in-package #:atbash-cipher)

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
-  "source": "Learn to Program by Chris Pine",
-  "files": {
-    "test": [
+  "source_url":"http://pine.fm/LearnToProgram/?Chapter=06",
+  "source":"Learn to Program by Chris Pine",
+  "files":{
+    "test":[
       "beer-song-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "beer-song.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/beer-song/beer-song-test.lisp
+++ b/exercises/practice/beer-song/beer-song-test.lisp
@@ -1,39 +1,40 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "beer-song")
+;; Ensures that beer-song.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "beer-song")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from beer-song and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:beer-song-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:beer-song-test)
 
-(defparameter +verse-8+
-  (format nil
-          "8 bottles of beer on the wall, 8 bottles of beer.~&~
-           Take one down and pass it around, 7 bottles of beer on the wall.~&"))
-(defparameter +verse-2+
-  (format nil
-          "2 bottles of beer on the wall, 2 bottles of beer.~&~
-           Take one down and pass it around, 1 bottle of beer on the wall.~&"))
-(defparameter +verse-1+
-  (format nil
-          "1 bottle of beer on the wall, 1 bottle of beer.~&~
-           Take it down and pass it around, no more bottles of beer on the wall.~&"))
+;; Define and enter a new FiveAM test-suite
+(def-suite* beer-song-suite)
+
 (defparameter +verse-0+
   (format nil
           "No more bottles of beer on the wall, no more bottles of beer.~&~
            Go to the store and buy some more, 99 bottles of beer on the wall.~&"))
 
-(defparameter +song-8-6+
+(defparameter +verse-1+
+  (format nil
+          "1 bottle of beer on the wall, 1 bottle of beer.~&~
+           Take it down and pass it around, no more bottles of beer on the wall.~&"))
+
+(defparameter +verse-2+
+  (format nil
+          "2 bottles of beer on the wall, 2 bottles of beer.~&~
+           Take one down and pass it around, 1 bottle of beer on the wall.~&"))
+
+(defparameter +verse-8+
   (format nil
           "8 bottles of beer on the wall, 8 bottles of beer.~&~
-           Take one down and pass it around, 7 bottles of beer on the wall.~&~
-           ~%~
-           7 bottles of beer on the wall, 7 bottles of beer.~&~
-           Take one down and pass it around, 6 bottles of beer on the wall.~&~
-           ~%~
-           6 bottles of beer on the wall, 6 bottles of beer.~&~
-           Take one down and pass it around, 5 bottles of beer on the wall.~&~
-           ~%"))
+           Take one down and pass it around, 7 bottles of beer on the wall.~&"))
+
 (defparameter +song-3-0+
   (format nil
           "3 bottles of beer on the wall, 3 bottles of beer.~&~
@@ -49,16 +50,25 @@
            Go to the store and buy some more, 99 bottles of beer on the wall.~&~
            ~%"))
 
-(define-test test-verse
-  (assert-equal +verse-8+ (beer-song:verse 8))
-  (assert-equal +verse-2+ (beer-song:verse 2))
-  (assert-equal +verse-1+ (beer-song:verse 1)))
+(defparameter +song-8-6+
+  (format nil
+          "8 bottles of beer on the wall, 8 bottles of beer.~&~
+           Take one down and pass it around, 7 bottles of beer on the wall.~&~
+           ~%~
+           7 bottles of beer on the wall, 7 bottles of beer.~&~
+           Take one down and pass it around, 6 bottles of beer on the wall.~&~
+           ~%~
+           6 bottles of beer on the wall, 6 bottles of beer.~&~
+           Take one down and pass it around, 5 bottles of beer on the wall.~&~
+           ~%"))
 
-(define-test test-song
-  (assert-equal +song-8-6+ (beer-song:sing 8 6))
-  (assert-equal +song-3-0+ (beer-song:sing 3)))
+(test test-verse (is (equal +verse-8+ (beer-song:verse 8)))
+ (is (equal +verse-2+ (beer-song:verse 2)))
+ (is (equal +verse-1+ (beer-song:verse 1))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :beer-song-test))
+(test test-song (is (equal +song-8-6+ (beer-song:sing 8 6)))
+ (is (equal +song-3-0+ (beer-song:sing 3))))
+
+(defun run-tests (&optional (test-or-suite 'beer-song-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/beer-song/beer-song.lisp
+++ b/exercises/practice/beer-song/beer-song.lisp
@@ -1,5 +1,5 @@
 (defpackage #:beer-song
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:verse #:sing))
 
 (in-package #:beer-song)

--- a/exercises/practice/beer-song/beer-song.lisp
+++ b/exercises/practice/beer-song/beer-song.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:beer-song
   (:use #:common-lisp)
   (:export #:verse #:sing))

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm",
-  "source": "Wikipedia",
-  "files": {
-    "test": [
+  "source_url":"http://en.wikipedia.org/wiki/Binary_search_algorithm",
+  "source":"Wikipedia",
+  "files":{
+    "test":[
       "binary-search-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "binary-search.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/binary-search/binary-search-test.lisp
+++ b/exercises/practice/binary-search/binary-search-test.lisp
@@ -1,45 +1,58 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "binary-search")
+;; Ensures that binary-search.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "binary-search")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from binary-search and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:binary-search-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:binary-search-test)
 
-(define-test finds-a-value-in-an-array-with-one-element
-  (assert-equal (binary-search:binary-find #(6) 6) 0))
+;; Define and enter a new FiveAM test-suite
+(def-suite* binary-search-suite)
 
-(define-test finds-a-value-in-the-middle-of-an-array
-  (assert-equal (binary-search:binary-find #(1 3 4 6 8 9 11) 6) 3))
+(test finds-a-value-in-an-array-with-one-element
+ (is (equal (binary-search:binary-find #(6) 6) 0)))
 
-(define-test finds-a-value-at-the-beginning-of-an-array
-  (assert-equal (binary-search:binary-find #(1 3 4 6 8 9 11) 1) 0))
+(test finds-a-value-in-the-middle-of-an-array
+ (is (equal (binary-search:binary-find #(1 3 4 6 8 9 11) 6) 3)))
 
-(define-test finds-a-value-at-the-end-of-an-array
-  (assert-equal (binary-search:binary-find #(1 3 4 6 8 9 11) 11) 6))
+(test finds-a-value-at-the-beginning-of-an-array
+ (is (equal (binary-search:binary-find #(1 3 4 6 8 9 11) 1) 0)))
 
-(define-test finds-a-value-in-an-array-of-odd-length
-  (assert-equal (binary-search:binary-find #(1 3 5 8 13 21 34 55 89 144 233 377 634) 144) 9))
+(test finds-a-value-at-the-end-of-an-array
+ (is (equal (binary-search:binary-find #(1 3 4 6 8 9 11) 11) 6)))
 
-(define-test finds-a-value-in-an-array-of-even-length
-  (assert-equal (binary-search:binary-find #(1 3 5 8 13 21 34 55 89 144 233 377) 21) 5))
+(test finds-a-value-in-an-array-of-odd-length
+ (is
+  (equal
+   (binary-search:binary-find #(1 3 5 8 13 21 34 55 89 144 233 377 634) 144)
+   9)))
 
-(define-test identifies-that-a-value-is-not-included-in-the-array
-  (assert-equal (binary-search:binary-find #(1 3 4 6 8 9 11) 7) nil))
+(test finds-a-value-in-an-array-of-even-length
+ (is
+  (equal (binary-search:binary-find #(1 3 5 8 13 21 34 55 89 144 233 377) 21)
+         5)))
 
-(define-test a-value-smaller-than-the-array-s-smallest-value-is-not-found
-  (assert-equal (binary-search:binary-find #(1 3 4 6 8 9 11) 0) nil))
+(test identifies-that-a-value-is-not-included-in-the-array
+ (is (equal (binary-search:binary-find #(1 3 4 6 8 9 11) 7) nil)))
 
-(define-test a-value-larger-than-the-array-s-largest-value-is-not-found
-  (assert-equal (binary-search:binary-find #(1 3 4 6 8 9 11) 13) nil))
+(test a-value-smaller-than-the-array-s-smallest-value-is-not-found
+ (is (equal (binary-search:binary-find #(1 3 4 6 8 9 11) 0) nil)))
 
-(define-test nothing-is-found-in-an-empty-array
-  (assert-equal (binary-search:binary-find #() 1) nil))
+(test a-value-larger-than-the-array-s-largest-value-is-not-found
+ (is (equal (binary-search:binary-find #(1 3 4 6 8 9 11) 13) nil)))
 
-(define-test nothing-is-found-when-the-left-and-right-bounds-cross
-  (assert-equal (binary-search:binary-find #(1 2) 0) nil))
+(test nothing-is-found-in-an-empty-array
+ (is (equal (binary-search:binary-find #() 1) nil)))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :binary-search-test))
+(test nothing-is-found-when-the-left-and-right-bounds-cross
+ (is (equal (binary-search:binary-find #(1 2) 0) nil)))
+
+(defun run-tests (&optional (test-or-suite 'binary-search-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/binary-search/binary-search.lisp
+++ b/exercises/practice/binary-search/binary-search.lisp
@@ -1,5 +1,5 @@
 (defpackage #:binary-search
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:binary-find #:value-error))
 
 (in-package #:binary-search)

--- a/exercises/practice/binary-search/binary-search.lisp
+++ b/exercises/practice/binary-search/binary-search.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:binary-search
   (:use #:common-lisp)
   (:export #:binary-find #:value-error))

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
-  "source": "All of Computer Science",
-  "files": {
-    "test": [
+  "source_url":"http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
+  "source":"All of Computer Science",
+  "files":{
+    "test":[
       "binary-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "binary.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/binary/binary-test.lisp
+++ b/exercises/practice/binary/binary-test.lisp
@@ -1,48 +1,45 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "binary")
+;; Ensures that binary.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "binary")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from binary and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:binary-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:binary-test)
 
-(define-test binary-1-is-decimal-1
-  (assert-equal 1 (binary:to-decimal "1")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* binary-suite)
 
-(define-test binary-10-is-decimal-2
-  (assert-equal 2 (binary:to-decimal "10")))
+(test binary-1-is-decimal-1 (is (equal 1 (binary:to-decimal "1"))))
 
-(define-test binary-11-is-decimal-3
-  (assert-equal 3 (binary:to-decimal "11")))
+(test binary-10-is-decimal-2 (is (equal 2 (binary:to-decimal "10"))))
 
-(define-test binary-100-is-decimal-4
-  (assert-equal 4 (binary:to-decimal "100")))
+(test binary-11-is-decimal-3 (is (equal 3 (binary:to-decimal "11"))))
 
-(define-test binary-1001-is-decimal-9
-  (assert-equal 9 (binary:to-decimal "1001")))
+(test binary-100-is-decimal-4 (is (equal 4 (binary:to-decimal "100"))))
 
-(define-test binary-11010-is-decimal-26
-  (assert-equal 26 (binary:to-decimal "11010")))
+(test binary-1001-is-decimal-9 (is (equal 9 (binary:to-decimal "1001"))))
 
-(define-test binary-10001101000-is-decimal-1128
-  (assert-equal 1128 (binary:to-decimal "10001101000")))
+(test binary-11010-is-decimal-26 (is (equal 26 (binary:to-decimal "11010"))))
 
-(define-test invalid-binary-is-decimal-0
-  (assert-equal 0 (binary:to-decimal "carrot")))
+(test binary-10001101000-is-decimal-1128
+ (is (equal 1128 (binary:to-decimal "10001101000"))))
 
-(define-test invalid-characters-at-beginning
-  (assert-equal 2 (binary:to-decimal "a10")))
+(test invalid-binary-is-decimal-0 (is (equal 0 (binary:to-decimal "carrot"))))
 
-(define-test invalid-characters-at-end
-  (assert-equal 2 (binary:to-decimal "10a")))
+(test invalid-characters-at-beginning (is (equal 2 (binary:to-decimal "a10"))))
 
-(define-test invalid-characters-in-middle
-  (assert-equal 2 (binary:to-decimal "1a0")))
+(test invalid-characters-at-end (is (equal 2 (binary:to-decimal "10a"))))
 
-(define-test invalid-digits
-  (assert-equal 0 (binary:to-decimal "23")))
+(test invalid-characters-in-middle (is (equal 2 (binary:to-decimal "1a0"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(test invalid-digits (is (equal 0 (binary:to-decimal "23"))))
+
+(defun run-tests (&optional (test-or-suite 'binary-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
-  "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
-  "files": {
-    "test": [
+  "source_url":"http://pine.fm/LearnToProgram/?Chapter=06",
+  "source":"Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
+  "files":{
+    "test":[
       "bob-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "bob.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/bob/bob-test.lisp
+++ b/exercises/practice/bob/bob-test.lisp
@@ -1,191 +1,108 @@
-;;;
-;;; bob v1.6.0
-;;;
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "bob")
+;; Ensures that bob.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "bob")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from bob and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:bob-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
+
+;; Enter the testing package
 (in-package #:bob-test)
 
-(define-test
-  stating-something
-  (assert-equal
-    "Whatever."
-    (bob:response "Tom-ay-to, tom-aaaah-to.")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* bob-suite)
 
+(test stating-something
+ (is (equal "Whatever." (bob:response "Tom-ay-to, tom-aaaah-to."))))
 
-(define-test
-  shouting
-  (assert-equal
-    "Whoa, chill out!"
-    (bob:response "WATCH OUT!")))
+(test shouting (is (equal "Whoa, chill out!" (bob:response "WATCH OUT!"))))
 
+(test shouting-gibberish
+ (is (equal "Whoa, chill out!" (bob:response "FCECDFCAAB"))))
 
-(define-test
-  shouting-gibberish
-  (assert-equal
-    "Whoa, chill out!"
-    (bob:response "FCECDFCAAB")))
+(test asking-a-question
+ (is
+  (equal "Sure."
+         (bob:response "Does this cryogenic chamber make me look fat?"))))
 
+(test asking-a-numeric-question
+ (is (equal "Sure." (bob:response "You are, what, like 15?"))))
 
-(define-test
-  asking-a-question
-  (assert-equal
-    "Sure."
-    (bob:response "Does this cryogenic chamber make me look fat?")))
+(test asking-gibberish (is (equal "Sure." (bob:response "fffbbcbeab?"))))
 
+(test talking-forcefully (is (equal "Whatever." (bob:response "Hi there!"))))
 
-(define-test
-  asking-a-numeric-question
-  (assert-equal
-    "Sure."
-    (bob:response "You are, what, like 15?")))
+(test using-acronyms-in-regular-speech
+ (is
+  (equal "Whatever."
+         (bob:response "It's OK if you don't want to go work for NASA."))))
 
+(test forceful-question
+ (is
+  (equal "Calm down, I know what I'm doing!"
+         (bob:response "WHAT'S GOING ON?"))))
 
-(define-test
-  asking-gibberish
-  (assert-equal
-    "Sure."
-    (bob:response "fffbbcbeab?")))
+(test shouting-numbers
+ (is (equal "Whoa, chill out!" (bob:response "1, 2, 3 GO!"))))
 
+(test no-letters (is (equal "Whatever." (bob:response "1, 2, 3"))))
 
-(define-test
-  talking-forcefully
-  (assert-equal
-    "Whatever."
-    (bob:response "Hi there!")))
+(test question-with-no-letters (is (equal "Sure." (bob:response "4?"))))
 
+(test shouting-with-special-characters
+ (is
+  (equal "Whoa, chill out!"
+         (bob:response "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"))))
 
-(define-test
-  using-acronyms-in-regular-speech
-  (assert-equal
-    "Whatever."
-    (bob:response "It's OK if you don't want to go work for NASA.")))
+(test shouting-with-no-exclamation-mark
+ (is (equal "Whoa, chill out!" (bob:response "I HATE THE DENTIST"))))
 
+(test statement-containing-question-mark
+ (is (equal "Whatever." (bob:response "Ending with ? means a question."))))
 
-(define-test
-  forceful-question
-  (assert-equal
-    "Calm down, I know what I'm doing!"
-    (bob:response "WHAT'S GOING ON?")))
+(test non-letters-with-question (is (equal "Sure." (bob:response ":) ?"))))
 
+(test prattling-on
+ (is (equal "Sure." (bob:response "Wait! Hang on. Are you going to be OK?"))))
 
-(define-test
-  shouting-numbers
-  (assert-equal
-    "Whoa, chill out!"
-    (bob:response "1, 2, 3 GO!")))
+(test silence (is (equal "Fine. Be that way!" (bob:response ""))))
 
+(test prolonged-silence
+ (is (equal "Fine. Be that way!" (bob:response "          "))))
 
-(define-test
-  no-letters
-  (assert-equal
-    "Whatever."
-    (bob:response "1, 2, 3")))
+(test alternate-silence
+ (is (equal "Fine. Be that way!" (bob:response "										"))))
 
-
-(define-test
-  question-with-no-letters
-  (assert-equal
-    "Sure."
-    (bob:response "4?")))
-
-
-(define-test
-  shouting-with-special-characters
-  (assert-equal
-    "Whoa, chill out!"
-    (bob:response "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!")))
-
-
-(define-test
-  shouting-with-no-exclamation-mark
-  (assert-equal
-    "Whoa, chill out!"
-    (bob:response "I HATE THE DENTIST")))
-
-
-(define-test
-  statement-containing-question-mark
-  (assert-equal
-    "Whatever."
-    (bob:response "Ending with ? means a question.")))
-
-
-(define-test
-  non-letters-with-question
-  (assert-equal
-    "Sure."
-    (bob:response ":) ?")))
-
-
-(define-test
-  prattling-on
-  (assert-equal
-    "Sure."
-    (bob:response "Wait! Hang on. Are you going to be OK?")))
-
-
-(define-test
-  silence
-  (assert-equal
-    "Fine. Be that way!"
-    (bob:response "")))
-
-
-(define-test
-  prolonged-silence
-  (assert-equal
-    "Fine. Be that way!"
-    (bob:response "          ")))
-
-
-(define-test
-  alternate-silence
-  (assert-equal
-    "Fine. Be that way!"
-    (bob:response "										")))
-
-
-(define-test
-  multiple-line-question
-  (assert-equal
-    "Whatever."
-    (bob:response (format nil "~%
+(test multiple-line-question
+ (is
+  (equal "Whatever."
+         (bob:response
+          (format nil "~%
 Does this cryogenic chamber make me look fat?~%
-No."))))
+No.")))))
 
+(test starting-with-whitespace
+ (is (equal "Whatever." (bob:response "         hmmmmmmm..."))))
 
-(define-test
-  starting-with-whitespace
-  (assert-equal
-    "Whatever."
-    (bob:response "         hmmmmmmm...")))
+(test ending-with-whitespace
+ (is
+  (equal "Sure." (bob:response "Okay if like my  spacebar  quite a bit?   "))))
 
+(test other-whitespace
+ (is
+  (equal "Fine. Be that way!"
+         (bob:response
+          (format nil "~%
+        ")))))
 
-(define-test
-  ending-with-whitespace
-  (assert-equal
-    "Sure."
-    (bob:response "Okay if like my  spacebar  quite a bit?   ")))
+(test non-question-ending-with-whitespace
+ (is
+  (equal "Whatever."
+         (bob:response "This is a statement ending with whitespace      "))))
 
-
-(define-test
-  other-whitespace
-  (assert-equal
-    "Fine. Be that way!"
-    (bob:response (format nil "~%
-        "))))
-
-
-(define-test
-  non-question-ending-with-whitespace
-  (assert-equal
-    "Whatever."
-    (bob:response "This is a statement ending with whitespace      ")))
-
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(defun run-tests (&optional (test-or-suite 'bob-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/bob/bob.lisp
+++ b/exercises/practice/bob/bob.lisp
@@ -1,8 +1,6 @@
-(in-package #:cl-user)
 (defpackage #:bob
   (:use #:cl)
   (:export #:response))
 (in-package #:bob)
 
 (defun response (hey-bob))
-

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem",
-  "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
-  "files": {
-    "test": [
+  "source_url":"https://en.wikipedia.org/wiki/3x_%2B_1_problem",
+  "source":"An unsolved problem in mathematics named after mathematician Lothar Collatz",
+  "files":{
+    "test":[
       "collatz-conjecture-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "collatz-conjecture.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.lisp
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.lisp
@@ -1,31 +1,32 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "collatz-conjecture")
+;; Ensures that collatz-conjecture.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "collatz-conjecture")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from collatz-conjecture and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:collatz-conjecture-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:collatz-conjecture-test)
 
-(define-test steps-for-1
-  (assert-equal 0 (collatz-conjecture:collatz 1)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* collatz-conjecture-suite)
 
-(define-test steps-for-16
-  (assert-equal 4 (collatz-conjecture:collatz 16)))
+(test steps-for-1 (is (equal 0 (collatz-conjecture:collatz 1))))
 
-(define-test steps-for-12
-  (assert-equal 9 (collatz-conjecture:collatz 12)))
+(test steps-for-16 (is (equal 4 (collatz-conjecture:collatz 16))))
 
-(define-test steps-for-1000000
-  (assert-equal 152 (collatz-conjecture:collatz 1000000)))
+(test steps-for-12 (is (equal 9 (collatz-conjecture:collatz 12))))
 
-(define-test steps-for-0
-  (assert-equal NIL (collatz-conjecture:collatz 0)))
+(test steps-for-1000000 (is (equal 152 (collatz-conjecture:collatz 1000000))))
 
-(define-test steps-for-negative
-  (assert-equal NIL (collatz-conjecture:collatz (- 0 15))))
+(test steps-for-0 (is (equal nil (collatz-conjecture:collatz 0))))
 
+(test steps-for-negative (is (equal nil (collatz-conjecture:collatz (- 0 15)))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(defun run-tests (&optional (test-or-suite 'collatz-conjecture-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/collatz-conjecture/collatz-conjecture.lisp
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture.lisp
@@ -1,5 +1,5 @@
 (defpackage #:collatz-conjecture
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:collatz))
 
 (in-package #:collatz-conjecture)

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
-  "source": "J Dalbey's Programming Practice problems",
-  "files": {
-    "test": [
+  "source_url":"http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
+  "source":"J Dalbey's Programming Practice problems",
+  "files":{
+    "test":[
       "crypto-square-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "crypto-square.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/crypto-square/crypto-square-test.lisp
+++ b/exercises/practice/crypto-square/crypto-square-test.lisp
@@ -1,41 +1,43 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "crypto-square")
+;; Ensures that crypto-square.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "crypto-square")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from crypto-square and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:crypto-square-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:crypto-square-test)
 
-(define-test empty-plaintext-results-in-an-empty-ciphertext
-  (assert-equal
-   ""
-   (crypto-square:encipher "")))
-(define-test lowercase
-  (assert-equal
-   "a"
-   (crypto-square:encipher"A")))
-(define-test remove-spaces
-  (assert-equal
-   "b"
-   (crypto-square:encipher "  b ")))
-(define-test remove-punctuation
-  (assert-equal
-   "1"
-   (crypto-square:encipher "@1,%!")))
-(define-test 9-character-plaintext-results-in-3-chunks-of-3-characters
-  (assert-equal
-   "tsf hiu isn"
-   (crypto-square:encipher "This is fun!")))
-(define-test 8-character-plaintext-results-in-3-chunks-the-last-one-with-a-trailing-space
-  (assert-equal
-   "clu hlt io "
-   (crypto-square:encipher "Chill out.")))
-(define-test 54-character-plaintext-results-in-7-chunks-the-last-two-with-trailing-spaces
-  (assert-equal
-   "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
-   (crypto-square:encipher "If man was meant to stay on the ground, god would have given us roots.")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* crypto-square-suite)
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(test empty-plaintext-results-in-an-empty-ciphertext
+ (is (equal "" (crypto-square:encipher ""))))
+
+(test lowercase (is (equal "a" (crypto-square:encipher "A"))))
+
+(test remove-spaces (is (equal "b" (crypto-square:encipher "  b "))))
+
+(test remove-punctuation (is (equal "1" (crypto-square:encipher "@1,%!"))))
+
+(test 9-character-plaintext-results-in-3-chunks-of-3-characters
+ (is (equal "tsf hiu isn" (crypto-square:encipher "This is fun!"))))
+
+(test
+ 8-character-plaintext-results-in-3-chunks-the-last-one-with-a-trailing-space
+ (is (equal "clu hlt io " (crypto-square:encipher "Chill out."))))
+
+(test
+ 54-character-plaintext-results-in-7-chunks-the-last-two-with-trailing-spaces
+ (is
+  (equal "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
+         (crypto-square:encipher
+          "If man was meant to stay on the ground, god would have given us roots."))))
+
+(defun run-tests (&optional (test-or-suite 'crypto-square-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/crypto-square/crypto-square.lisp
+++ b/exercises/practice/crypto-square/crypto-square.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:crypto-square
   (:use #:cl)
   (:export #:encipher))

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://projecteuler.net/problem=6",
-  "source": "Problem 6 at Project Euler",
-  "files": {
-    "test": [
+  "source_url":"http://projecteuler.net/problem=6",
+  "source":"Problem 6 at Project Euler",
+  "files":{
+    "test":[
       "difference-of-squares-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "difference-of-squares.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/difference-of-squares/difference-of-squares-test.lisp
+++ b/exercises/practice/difference-of-squares/difference-of-squares-test.lisp
@@ -1,33 +1,47 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "difference-of-squares")
+;; Ensures that difference-of-squares.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "difference-of-squares")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from difference-of-squares and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:difference-of-squares-test
-  (:use #:cl #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:difference-of-squares-test)
 
-(define-test square-of-sum-to-5
-  (assert-equal 225 (difference-of-squares:square-of-sum 5)))
-(define-test sum-of-squares-to-5
-  (assert-equal 55 (difference-of-squares:sum-of-squares 5)))
-(define-test difference-of-sums-to-5
-  (assert-equal 170 (difference-of-squares:difference 5)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* difference-of-squares-suite)
 
-(define-test square-of-sum-to-10
-  (assert-equal 3025 (difference-of-squares:square-of-sum 10)))
-(define-test sum-of-squares-to-10
-  (assert-equal 385 (difference-of-squares:sum-of-squares 10)))
-(define-test difference-of-sums-to-10
-  (assert-equal 2640 (difference-of-squares:difference 10)))
+(test square-of-sum-to-5
+ (is (equal 225 (difference-of-squares:square-of-sum 5))))
 
-(define-test square-of-sum-to-100
-  (assert-equal 25502500 (difference-of-squares:square-of-sum 100)))
-(define-test sum-of-squares-to-100
-  (assert-equal 338350 (difference-of-squares:sum-of-squares 100)))
-(define-test difference-of-sums-to-100
-  (assert-equal 25164150 (difference-of-squares:difference 100)))
+(test sum-of-squares-to-5
+ (is (equal 55 (difference-of-squares:sum-of-squares 5))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :squares-test))
+(test difference-of-sums-to-5
+ (is (equal 170 (difference-of-squares:difference 5))))
+
+(test square-of-sum-to-10
+ (is (equal 3025 (difference-of-squares:square-of-sum 10))))
+
+(test sum-of-squares-to-10
+ (is (equal 385 (difference-of-squares:sum-of-squares 10))))
+
+(test difference-of-sums-to-10
+ (is (equal 2640 (difference-of-squares:difference 10))))
+
+(test square-of-sum-to-100
+ (is (equal 25502500 (difference-of-squares:square-of-sum 100))))
+
+(test sum-of-squares-to-100
+ (is (equal 338350 (difference-of-squares:sum-of-squares 100))))
+
+(test difference-of-sums-to-100
+ (is (equal 25164150 (difference-of-squares:difference 100))))
+
+(defun run-tests (&optional (test-or-suite 'difference-of-squares-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://jumpstartlab.com",
-  "source": "The Jumpstart Lab team",
-  "files": {
-    "test": [
+  "source_url":"http://jumpstartlab.com",
+  "source":"The Jumpstart Lab team",
+  "files":{
+    "test":[
       "etl-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "etl.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/etl/etl-test.lisp
+++ b/exercises/practice/etl/etl-test.lisp
@@ -1,47 +1,54 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "etl")
+;; Ensures that etl.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "etl")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from etl and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:etl-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:etl-test)
 
+;; Define and enter a new FiveAM test-suite
+(def-suite* etl-suite)
+
 (defun make-hash (kvs)
-  (reduce
-   #'(lambda (h kv) (setf (gethash (first kv) h) (second kv)) h)
-   kvs
-   :initial-value (make-hash-table :test 'equalp)))
+  (reduce #'(lambda (h kv) (setf (gethash (first kv) h) (second kv)) h) kvs
+          :initial-value (make-hash-table :test 'equalp)))
 
-(define-test transform-one-value
-  (assert-equalp (make-hash '(("world" 1)))
-      (etl:transform (make-hash '((1 ("WORLD")))))))
+(test transform-one-value
+ (is
+  (equalp (make-hash '(("world" 1)))
+          (etl:transform (make-hash '((1 ("WORLD"))))))))
 
-(define-test transform-more-values
-  (assert-equalp (make-hash '(("world" 1) ("gschoolers" 1)))
-      (etl:transform (make-hash '((1 ("WORLD" "GSCHOOLERS")))))))
+(test transform-more-values
+ (is
+  (equalp (make-hash '(("world" 1) ("gschoolers" 1)))
+          (etl:transform (make-hash '((1 ("WORLD" "GSCHOOLERS"))))))))
 
-(define-test more-keys
-  (assert-equalp (make-hash '(("apple" 1) ("artichoke" 1) ("boat" 2) ("ballerina" 2)))
-      (etl:transform (make-hash '((1 ("APPLE" "ARTICHOKE")) (2 ("BOAT" "BALLERINA")))))))
+(test more-keys
+ (is
+  (equalp (make-hash '(("apple" 1) ("artichoke" 1) ("boat" 2) ("ballerina" 2)))
+          (etl:transform
+           (make-hash '((1 ("APPLE" "ARTICHOKE")) (2 ("BOAT" "BALLERINA"))))))))
 
-(define-test full-dataset
-  (let ((input-data '((1 ("A" "E" "I" "O" "U" "L" "N" "R" "S" "T"))
-                      (2 ("D" "G"))
-                      (3 ("B" "C" "M" "P"))
-                      (4 ("F" "H" "V" "W" "Y"))
-                      (5 ("K"))
-                      (8 ("J" "X"))
-                      (10 ("Q" "Z"))))
-        (expected-output '(("a" 1) ("b" 3) ("c" 3) ("d" 2) ("e" 1)
-                           ("f" 4) ("g" 2) ("h" 4) ("i" 1) ("j" 8)
-                           ("k" 5) ("l" 1) ("m" 3) ("n" 1) ("o" 1)
-                           ("p" 3) ("q" 10) ("r" 1) ("s" 1) ("t" 1)
-                           ("u" 1) ("v" 4) ("w" 4) ("x" 8) ("y" 4)
-                           ("z" 10))))
-    (assert-equalp (make-hash expected-output)
-        (etl:transform (make-hash input-data)))))
+(test full-dataset
+ (let ((input-data
+        '((1 ("A" "E" "I" "O" "U" "L" "N" "R" "S" "T")) (2 ("D" "G"))
+          (3 ("B" "C" "M" "P")) (4 ("F" "H" "V" "W" "Y")) (5 ("K"))
+          (8 ("J" "X")) (10 ("Q" "Z"))))
+       (expected-output
+        '(("a" 1) ("b" 3) ("c" 3) ("d" 2) ("e" 1) ("f" 4) ("g" 2) ("h" 4)
+          ("i" 1) ("j" 8) ("k" 5) ("l" 1) ("m" 3) ("n" 1) ("o" 1) ("p" 3)
+          ("q" 10) ("r" 1) ("s" 1) ("t" 1) ("u" 1) ("v" 4) ("w" 4) ("x" 8)
+          ("y" 4) ("z" 10))))
+   (is
+    (equalp (make-hash expected-output)
+            (etl:transform (make-hash input-data))))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :etl-test))
+(defun run-tests (&optional (test-or-suite 'etl-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/etl/etl.lisp
+++ b/exercises/practice/etl/etl.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:etl
   (:use #:common-lisp)
   (:export #:transform))

--- a/exercises/practice/etl/etl.lisp
+++ b/exercises/practice/etl/etl.lisp
@@ -1,5 +1,5 @@
 (defpackage #:etl
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:transform))
 
 (in-package #:etl)

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://pine.fm/LearnToProgram/?Chapter=09",
-  "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
-  "files": {
-    "test": [
+  "source_url":"http://pine.fm/LearnToProgram/?Chapter=09",
+  "source":"Chapter 9 in Chris Pine's online Learn to Program tutorial.",
+  "files":{
+    "test":[
       "gigasecond-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "gigasecond.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/gigasecond/gigasecond-test.lisp
+++ b/exercises/practice/gigasecond/gigasecond-test.lisp
@@ -1,31 +1,35 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "gigasecond")
+;; Ensures that gigasecond.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "gigasecond")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from gigasecond and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:gigasecond-test
-  (:use #:cl #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:gigasecond-test)
 
-(define-test from-lisp-epoch
-  (assert-equal '(1931 9 10 1 46 40) (gigasecond:from 1900 1 1 0 0 0)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* gigasecond-suite)
 
-(define-test from-unix-epoch
-  (assert-equal '(2001 9 9 1 46 40) (gigasecond:from 1970 1 1 0 0 0)))
+(test from-lisp-epoch
+ (is (equal '(1931 9 10 1 46 40) (gigasecond:from 1900 1 1 0 0 0))))
 
-(define-test from-20110425T120000Z
-  (assert-equal '(2043 1 1 13 46 40) (gigasecond:from 2011 4 25 12 0 0)))
+(test from-unix-epoch
+ (is (equal '(2001 9 9 1 46 40) (gigasecond:from 1970 1 1 0 0 0))))
 
-(define-test from-19770613T235959Z
-  (assert-equal '(2009 2 20 1 46 39) (gigasecond:from 1977 6 13 23 59 59)))
+(test from-20110425t120000z
+ (is (equal '(2043 1 1 13 46 40) (gigasecond:from 2011 4 25 12 0 0))))
 
-(define-test from-19590719T123030Z
-  (assert-equal '(1991 3 27 14 17 10) (gigasecond:from 1959 7 19 12 30 30)))
+(test from-19770613t235959z
+ (is (equal '(2009 2 20 1 46 39) (gigasecond:from 1977 6 13 23 59 59))))
 
-; customize this to test your birthday and find your gigasecond date:
-; (define-test your-birthday
-;   (assert-equal '(year2 month2 day2) (gigasecond:from year1 month1 day1)))
+(test from-19590719t123030z
+ (is (equal '(1991 3 27 14 17 10) (gigasecond:from 1959 7 19 12 30 30))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :gigasecond-test))
+(defun run-tests (&optional (test-or-suite 'gigasecond-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/gigasecond/gigasecond.lisp
+++ b/exercises/practice/gigasecond/gigasecond.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:gigasecond
   (:use #:cl)
   (:export #:from))

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://gschool.it",
-  "source": "A pairing session with Phil Battos at gSchool",
-  "files": {
-    "test": [
+  "source_url":"http://gschool.it",
+  "source":"A pairing session with Phil Battos at gSchool",
+  "files":{
+    "test":[
       "grade-school-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "grade-school.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/grade-school/grade-school-test.lisp
+++ b/exercises/practice/grade-school/grade-school-test.lisp
@@ -1,63 +1,76 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "grade-school")
+;; Ensures that grade-school.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "grade-school")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from grade-school and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:grade-school-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:grade-school-test)
 
-(define-test grade-roster-is-initially-empty
-  (let ((school (grade-school:make-school)))
-    (assert-equalp '() (grade-school:grade-roster school))))
+;; Define and enter a new FiveAM test-suite
+(def-suite* grade-school-suite)
 
-(define-test add-student
-  (let ((school (grade-school:make-school)))
-    (grade-school:add school "Aimee" 2)
-    (assert-equalp '((:grade 2 :students ("Aimee")))
-                   (grade-school:grade-roster school))))
+(test grade-roster-is-initially-empty
+ (let ((school (grade-school:make-school)))
+   (is (equalp 'nil (grade-school:grade-roster school)))))
 
-(define-test add-more-students-in-same-class
-  (let ((school (grade-school:make-school)))
-    (grade-school:add school "James" 2)
-    (grade-school:add school "Blair" 2)
-    (grade-school:add school "Paul" 2)
-    (let ((grade2 (first (grade-school:grade-roster school))))
-      (assert-equalp 2 (getf grade2 :grade))
-      (assert-equalp '("Blair" "James" "Paul")
-                     (sort (getf grade2 :students) #'string<)))))
+(test add-student
+ (let ((school (grade-school:make-school)))
+   (grade-school:add school "Aimee" 2)
+   (is
+    (equalp '((:grade 2 :students ("Aimee")))
+            (grade-school:grade-roster school)))))
 
-(define-test add-students-to-different-grades
-  (let ((school (grade-school:make-school)))
-    (grade-school:add school "Chelsea" 3)
-    (grade-school:add school "Logan" 7)
-    (assert-equalp '((:grade 3 :students ("Chelsea"))
-                     (:grade 7 :students ("Logan")))
-                   (sort (grade-school:grade-roster school) #'< :key #'second))))
+(test add-more-students-in-same-class
+ (let ((school (grade-school:make-school)))
+   (grade-school:add school "James" 2)
+   (grade-school:add school "Blair" 2)
+   (grade-school:add school "Paul" 2)
+   (let ((grade2 (first (grade-school:grade-roster school))))
+     (is (equalp 2 (getf grade2 :grade)))
+     (is
+      (equalp '("Blair" "James" "Paul")
+              (sort (getf grade2 :students) #'string<))))))
 
-(define-test get-students-in-a-grade
-  (let ((school (grade-school:make-school)))
-    (grade-school:add school "Franklin" 5)
-    (grade-school:add school "Bradley" 5)
-    (grade-school:add school "Jeff" 1)
-    (assert-equalp '("Bradley" "Franklin")
-                   (sort (grade-school:grade school 5) #'string<))))
+(test add-students-to-different-grades
+ (let ((school (grade-school:make-school)))
+   (grade-school:add school "Chelsea" 3)
+   (grade-school:add school "Logan" 7)
+   (is
+    (equalp '((:grade 3 :students ("Chelsea")) (:grade 7 :students ("Logan")))
+            (sort (grade-school:grade-roster school) #'< :key #'second)))))
 
-(define-test get-students-in-a-non-existant-grade
-  (let ((school (grade-school:make-school)))
-    (assert-equalp '() (grade-school:grade school 1))))
+(test get-students-in-a-grade
+ (let ((school (grade-school:make-school)))
+   (grade-school:add school "Franklin" 5)
+   (grade-school:add school "Bradley" 5)
+   (grade-school:add school "Jeff" 1)
+   (is
+    (equalp '("Bradley" "Franklin")
+            (sort (grade-school:grade school 5) #'string<)))))
 
-(define-test sorted-school
-  (let ((school (grade-school:make-school)))
-    (grade-school:add school "Jennifer" 4)
-    (grade-school:add school "Kareem" 6)
-    (grade-school:add school "Christopher" 4)
-    (grade-school:add school "Kyle" 3)
-    (assert-equalp '((:grade 3 :students ("Kyle"))
-                     (:grade 4 :students ("Christopher" "Jennifer"))
-                     (:grade 6 :students ("Kareem")))
-                   (grade-school:sorted school))))
+(test get-students-in-a-non-existant-grade
+ (let ((school (grade-school:make-school)))
+   (is (equalp 'nil (grade-school:grade school 1)))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :grade-school-test))
+(test sorted-school
+ (let ((school (grade-school:make-school)))
+   (grade-school:add school "Jennifer" 4)
+   (grade-school:add school "Kareem" 6)
+   (grade-school:add school "Christopher" 4)
+   (grade-school:add school "Kyle" 3)
+   (is
+    (equalp
+     '((:grade 3 :students ("Kyle"))
+       (:grade 4 :students ("Christopher" "Jennifer"))
+       (:grade 6 :students ("Kareem")))
+     (grade-school:sorted school)))))
+
+(defun run-tests (&optional (test-or-suite 'grade-school-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/grade-school/grade-school.lisp
+++ b/exercises/practice/grade-school/grade-school.lisp
@@ -1,5 +1,5 @@
 (defpackage #:grade-school
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:make-school #:add #:grade-roster #:grade #:sorted))
 
 (in-package #:grade-school)

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://www.javaranch.com/grains.jsp",
-  "source": "JavaRanch Cattle Drive, exercise 6",
-  "files": {
-    "test": [
+  "source_url":"http://www.javaranch.com/grains.jsp",
+  "source":"JavaRanch Cattle Drive, exercise 6",
+  "files":{
+    "test":[
       "grains-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "grains.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/grains/grains-test.lisp
+++ b/exercises/practice/grains/grains-test.lisp
@@ -1,36 +1,36 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "grains")
+;; Ensures that grains.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "grains")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from grains and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:grains-test
-  (:use #:cl #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:grains-test)
 
-(define-test square-1
-  (assert-equal 1 (grains:square 1)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* grains-suite)
 
-(define-test square-2
-  (assert-equal 2 (grains:square 2)))
+(test square-1 (is (equal 1 (grains:square 1))))
 
-(define-test square-3
-  (assert-equal 4 (grains:square 3)))
+(test square-2 (is (equal 2 (grains:square 2))))
 
-(define-test square-4
-  (assert-equal 8 (grains:square 4)))
+(test square-3 (is (equal 4 (grains:square 3))))
 
-(define-test square-16
-  (assert-equal 32768 (grains:square 16)))
+(test square-4 (is (equal 8 (grains:square 4))))
 
-(define-test square-32
-  (assert-equal 2147483648 (grains:square 32)))
+(test square-16 (is (equal 32768 (grains:square 16))))
 
-(define-test square-64
-  (assert-equal 9223372036854775808 (grains:square 64)))
+(test square-32 (is (equal 2147483648 (grains:square 32))))
 
-(define-test total-grains
-  (assert-equal 18446744073709551615  (grains:total)))
+(test square-64 (is (equal 9223372036854775808 (grains:square 64))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :grains-test))
+(test total-grains (is (equal 18446744073709551615 (grains:total))))
+
+(defun run-tests (&optional (test-or-suite 'grains-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/grains/grains.lisp
+++ b/exercises/practice/grains/grains.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:grains
   (:use #:cl)
   (:export :square :total))

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://rosalind.info/problems/hamm/",
-  "source": "The Calculating Point Mutations problem at Rosalind",
-  "files": {
-    "test": [
+  "source_url":"http://rosalind.info/problems/hamm/",
+  "source":"The Calculating Point Mutations problem at Rosalind",
+  "files":{
+    "test":[
       "hamming-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "hamming.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/hamming/hamming-test.lisp
+++ b/exercises/practice/hamming/hamming-test.lisp
@@ -1,32 +1,42 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "hamming")
+;; Ensures that hamming.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "hamming")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from hamming and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:hamming-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:hamming-test)
 
-(define-test no-difference-between-empty-strands
-  (assert-equal 0 (hamming:distance "" "")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* hamming-suite)
 
-(define-test no-difference-between-identical-strands
-  (assert-equal 0 (hamming:distance "GGACTGA" "GGACTGA")))
+(test no-difference-between-empty-strands
+ (is (equal 0 (hamming:distance "" ""))))
 
-(define-test complete-hamming-distance-in-small-strand
-  (assert-equal 3 (hamming:distance "ACT" "GGA")))
+(test no-difference-between-identical-strands
+ (is (equal 0 (hamming:distance "GGACTGA" "GGACTGA"))))
 
-(define-test small-hamming-distance-in-middle-somewhere
-  (assert-equal 1 (hamming:distance "GGACG" "GGTCG")))
+(test complete-hamming-distance-in-small-strand
+ (is (equal 3 (hamming:distance "ACT" "GGA"))))
 
-(define-test larger-distance
-  (assert-equal 2 (hamming:distance "ACCAGGG" "ACTATGG")))
+(test small-hamming-distance-in-middle-somewhere
+ (is (equal 1 (hamming:distance "GGACG" "GGTCG"))))
 
-(define-test invalid-to-get-distance-for-different-length-strings
-  (assert-equal nil (hamming:distance "AGACAACAGCCAGCCGCCGGATT" "AGGCAA"))
-  (assert-equal nil (hamming:distance "AGACAACAGCCAGCCGCCGGATT" "AGACATCTTTCAGCCGCCGGATTAGGCAA"))
-  (assert-equal nil (hamming:distance "AGG" "AGACAACAGCCAGCCGCCGGATT")))
+(test larger-distance (is (equal 2 (hamming:distance "ACCAGGG" "ACTATGG"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :hamming-test))
+(test invalid-to-get-distance-for-different-length-strings
+ (is (equal nil (hamming:distance "AGACAACAGCCAGCCGCCGGATT" "AGGCAA")))
+ (is
+  (equal nil
+         (hamming:distance "AGACAACAGCCAGCCGCCGGATT"
+                           "AGACATCTTTCAGCCGCCGGATTAGGCAA")))
+ (is (equal nil (hamming:distance "AGG" "AGACAACAGCCAGCCGCCGGATT"))))
+
+(defun run-tests (&optional (test-or-suite 'hamming-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
-  "source": "This is an exercise to introduce users to using Exercism",
-  "files": {
-    "test": [
+  "source_url":"http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
+  "source":"This is an exercise to introduce users to using Exercism",
+  "files":{
+    "test":[
       "hello-world-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "hello-world.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/hello-world/hello-world-test.lisp
+++ b/exercises/practice/hello-world/hello-world-test.lisp
@@ -1,20 +1,22 @@
-;;; 
-;;; hello-world v1.1.0
-;;; 
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "hello-world")
+;; Ensures that hello-world.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "hello-world")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from hello-world and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:hello-world-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
+
+;; Enter the testing package
 (in-package #:hello-world-test)
 
-(define-test
-  say-hi!
-  (assert-equal
-    "Hello, World!"
-    (hello-world:hello)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* hello-world-suite)
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(test say-hi! (is (equal "Hello, World!" (hello-world:hello))))
+
+(defun run-tests (&optional (test-or-suite 'hello-world-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/hello-world/hello-world.lisp
+++ b/exercises/practice/hello-world/hello-world.lisp
@@ -1,8 +1,6 @@
-(in-package #:cl-user)
 (defpackage #:hello-world
   (:use #:cl)
   (:export #:hello))
 (in-package #:hello-world)
 
 (defun hello NIL)
-

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://en.wikipedia.org/wiki/Isogram",
-  "source": "Wikipedia",
-  "files": {
-    "test": [
+  "source_url":"https://en.wikipedia.org/wiki/Isogram",
+  "source":"Wikipedia",
+  "files":{
+    "test":[
       "isogram-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "isogram.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/isogram/isogram-test.lisp
+++ b/exercises/practice/isogram/isogram-test.lisp
@@ -1,39 +1,45 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "isogram")
+;; Ensures that isogram.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "isogram")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from isogram and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:isogram-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:isogram-test)
 
-(define-test empty-string
-  (assert-true (isogram:is-isogram "")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* isogram-suite)
 
-(define-test isogram-with-only-lower-case-characters
-  (assert-true (isogram:is-isogram "isogram")))
+(test empty-string (is (isogram:is-isogram "")))
 
-(define-test word-with-one-duplicated-character
-  (assert-false (isogram:is-isogram "eleven")))
+(test isogram-with-only-lower-case-characters
+ (is (isogram:is-isogram "isogram")))
 
-(define-test longest-reported-english-isogram
-  (assert-true (isogram:is-isogram "subdermatoglyphic")))
+(test word-with-one-duplicated-character
+ (is (not (isogram:is-isogram "eleven"))))
 
-(define-test word-with-duplicated-character-in-mixed-case
-  (assert-false (isogram:is-isogram "Alphabet")))
+(test longest-reported-english-isogram
+ (is (isogram:is-isogram "subdermatoglyphic")))
 
-(define-test hypothetical-isogrammic-word-with-hyphen
-  (assert-true (isogram:is-isogram "thumbscrew-japingly")))
+(test word-with-duplicated-character-in-mixed-case
+ (is (not (isogram:is-isogram "Alphabet"))))
 
-(define-test isogram-with-duplicated-hyphen
-  (assert-true (isogram:is-isogram "six-year-old")))
+(test hypothetical-isogrammic-word-with-hyphen
+ (is (isogram:is-isogram "thumbscrew-japingly")))
 
-(define-test made-up-name-that-is-an-isogam
-  (assert-true (isogram:is-isogram "Emily Jung Schwartzkopf")))
+(test isogram-with-duplicated-hyphen (is (isogram:is-isogram "six-year-old")))
 
-(define-test duplicated-character-in-the-middle
-  (assert-false (isogram:is-isogram "accentor")))
+(test made-up-name-that-is-an-isogam
+ (is (isogram:is-isogram "Emily Jung Schwartzkopf")))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :isogram-test))
+(test duplicated-character-in-the-middle
+ (is (not (isogram:is-isogram "accentor"))))
+
+(defun run-tests (&optional (test-or-suite 'isogram-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://www.javaranch.com/leap.jsp",
-  "source": "JavaRanch Cattle Drive, exercise 3",
-  "files": {
-    "test": [
+  "source_url":"http://www.javaranch.com/leap.jsp",
+  "source":"JavaRanch Cattle Drive, exercise 3",
+  "files":{
+    "test":[
       "leap-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "leap.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/leap/leap-test.lisp
+++ b/exercises/practice/leap/leap-test.lisp
@@ -1,27 +1,30 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "leap")
+;; Ensures that leap.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "leap")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from leap and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:leap-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:leap-test)
 
-(define-test vanilla-leap-year
-  (assert-true (leap:leap-year-p 1996)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* leap-suite)
 
-(define-test any-old-year
-  (assert-false (leap:leap-year-p 1997)))
+(test vanilla-leap-year (is (leap:leap-year-p 1996)))
 
-(define-test non-leap-even-year
-  (assert-false (leap:leap-year-p 1998)))
+(test any-old-year (is (not (leap:leap-year-p 1997))))
 
-(define-test century
-  (assert-false (leap:leap-year-p 1900)))
+(test non-leap-even-year (is (not (leap:leap-year-p 1998))))
 
-(define-test exceptional-century
-  (assert-true (leap:leap-year-p 2400)))
+(test century (is (not (leap:leap-year-p 1900))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :leap-test))
+(test exceptional-century (is (leap:leap-year-p 2400)))
+
+(defun run-tests (&optional (test-or-suite 'leap-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/leap/leap.lisp
+++ b/exercises/practice/leap/leap.lisp
@@ -1,5 +1,5 @@
 (defpackage #:leap
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:leap-year-p))
 (in-package #:leap)
 

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm",
-  "source": "The Luhn Algorithm on Wikipedia",
-  "files": {
-    "test": [
+  "source_url":"http://en.wikipedia.org/wiki/Luhn_algorithm",
+  "source":"The Luhn Algorithm on Wikipedia",
+  "files":{
+    "test":[
       "luhn-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "luhn.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/luhn/luhn-test.lisp
+++ b/exercises/practice/luhn/luhn-test.lisp
@@ -1,54 +1,54 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "luhn")
+;; Ensures that luhn.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "luhn")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from luhn and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:luhn-test
-  (:use #:cl #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:luhn-test)
 
-(define-test single-digit-strings-can-not-be-valid
-  (assert-false (luhn:validp "1")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* luhn-suite)
 
-(define-test a-single-zero-is-invalid
-  (assert-false (luhn:validp "0")))
+(test single-digit-strings-can-not-be-valid (is (not (luhn:validp "1"))))
 
-(define-test a-simple-valid-sin-that-remains-valid-if-reversed
-  (assert-true (luhn:validp "059")))
+(test a-single-zero-is-invalid (is (not (luhn:validp "0"))))
 
-(define-test a-simple-valid-sin-that-becomes-invalid-if-reversed
-  (assert-true (luhn:validp "59")))
+(test a-simple-valid-sin-that-remains-valid-if-reversed
+ (is (luhn:validp "059")))
 
-(define-test a-valid-canadian-sin
-  (assert-true (luhn:validp "055 444 285")))
+(test a-simple-valid-sin-that-becomes-invalid-if-reversed
+ (is (luhn:validp "59")))
 
-(define-test invalid-canadian-sin
-  (assert-false (luhn:validp "055 444 286")))
+(test a-valid-canadian-sin (is (luhn:validp "055 444 285")))
 
-(define-test invalid-credit-card
-  (assert-false (luhn:validp "8273 1232 7352 0569")))
+(test invalid-canadian-sin (is (not (luhn:validp "055 444 286"))))
 
-(define-test valid-strings-with-a-non-digit-included-become-invalid
-  (assert-false (luhn:validp "055a 444 285")))
+(test invalid-credit-card (is (not (luhn:validp "8273 1232 7352 0569"))))
 
-(define-test valid-strings-with-punctuation-included-become-invalid
-  (assert-false (luhn:validp "055-444-285")))
+(test valid-strings-with-a-non-digit-included-become-invalid
+ (is (not (luhn:validp "055a 444 285"))))
 
-(define-test valid-strings-with-symbols-included-become-invalid
-  (assert-false (luhn:validp "055£ 444$ 285")))
+(test valid-strings-with-punctuation-included-become-invalid
+ (is (not (luhn:validp "055-444-285"))))
 
-(define-test single-zero-with-space-is-invalid
-  (assert-false (luhn:validp " 0")))
+(test valid-strings-with-symbols-included-become-invalid
+ (is (not (luhn:validp "055£ 444$ 285"))))
 
-(define-test more-than-a-single-zero-validp
-  (assert-true (luhn:validp "0000 0")))
+(test single-zero-with-space-is-invalid (is (not (luhn:validp " 0"))))
 
-(define-test input-digit-9-is-correctly-converted-to-output-digit-9
-  (assert-true (luhn:validp "091")))
+(test more-than-a-single-zero-validp (is (luhn:validp "0000 0")))
 
-(define-test strings-with-non-digits-is-invalid
-  (assert-false (luhn:validp ":9")))
+(test input-digit-9-is-correctly-converted-to-output-digit-9
+ (is (luhn:validp "091")))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :luhn-test))
+(test strings-with-non-digits-is-invalid (is (not (luhn:validp ":9"))))
+
+(defun run-tests (&optional (test-or-suite 'luhn-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/luhn/luhn.lisp
+++ b/exercises/practice/luhn/luhn.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:luhn
   (:use #:cl)
   (:export #:validp))

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://twitter.com/copiousfreetime",
-  "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
-  "files": {
-    "test": [
+  "source_url":"https://twitter.com/copiousfreetime",
+  "source":"Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
+  "files":{
+    "test":[
       "meetup-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "meetup.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/meetup/meetup-test.lisp
+++ b/exercises/practice/meetup/meetup-test.lisp
@@ -1,236 +1,293 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "meetup")
+;; Ensures that meetup.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "meetup")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from meetup and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:meetup-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:meetup-test)
 
-(define-test monteeth-of-may-2013
-  (assert-equal '(2013 5 13) (meetup:meetup 5 2013 :monday :teenth)))
-(define-test monteenth-of-august-2013
-  (assert-equal '(2013 8 19) (meetup:meetup 8 2013 :monday :teenth)))
-(define-test monteenth-of-september-2013
-  (assert-equal '(2013 9 16) (meetup:meetup 9 2013 :monday :Teenth)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* meetup-suite)
 
-(define-test tuesteenth-of-march-2013
-  (assert-equal '(2013 3 19) (meetup:meetup 3 2013 :tuesday :teenth)))
-(define-test tuesteenth-of-april-2013
-  (assert-equal '(2013 4 16) (meetup:meetup 4 2013 :tuesday :teenth)))
-(define-test tuesteenth-of-august-2013
-  (assert-equal '(2013 8 13) (meetup:meetup 8 2013 :tuesday :teenth)))
+(test monteeth-of-may-2013
+ (is (equal '(2013 5 13) (meetup:meetup 5 2013 :monday :teenth))))
 
-(define-test wednesteenth-of-january-2013
-  (assert-equal '(2013 1 16) (meetup:meetup 1 2013 :wednesday :teenth)))
-(define-test wednesteenth-of-february-2013
-  (assert-equal '(2013 2 13) (meetup:meetup 2 2013 :wednesday :teenth)))
-(define-test wednesteenth-of-june-2013
-  (assert-equal '(2013 6 19) (meetup:meetup 6 2013 :wednesday :teenth)))
+(test monteenth-of-august-2013
+ (is (equal '(2013 8 19) (meetup:meetup 8 2013 :monday :teenth))))
 
-(define-test thursteenth-of-may-2013
-  (assert-equal '(2013 5 16) (meetup:meetup 5 2013 :thursday :teenth)))
-(define-test thursteenth-of-june-2013
-  (assert-equal '(2013 6 13) (meetup:meetup 6 2013 :thursday :teenth)))
-(define-test thursteenth-of-september-2013
-  (assert-equal '(2013 9 19) (meetup:meetup 9 2013 :thursday :teenth)))
+(test monteenth-of-september-2013
+ (is (equal '(2013 9 16) (meetup:meetup 9 2013 :monday :teenth))))
 
-(define-test friteenth-of-april-2013
-  (assert-equal '(2013 4 19) (meetup:meetup 4 2013 :friday :teenth)))
-(define-test friteenth-of-august-2013
-  (assert-equal '(2013 8 16) (meetup:meetup 8 2013 :friday :teenth)))
-(define-test friteenth-of-september-2013
-  (assert-equal '(2013 9 13) (meetup:meetup 9 2013 :friday :teenth)))
+(test tuesteenth-of-march-2013
+ (is (equal '(2013 3 19) (meetup:meetup 3 2013 :tuesday :teenth))))
 
-(define-test saturteenth-of-february-2013
-  (assert-equal '(2013 2 16) (meetup:meetup 2 2013 :saturday :teenth)))
-(define-test saturteenth-of-april-2013
-  (assert-equal '(2013 4 13) (meetup:meetup 4 2013 :saturday :teenth)))
-(define-test saturteenth-of-october-2013
-  (assert-equal '(2013 10 19) (meetup:meetup 10 2013 :saturday :teenth)))
+(test tuesteenth-of-april-2013
+ (is (equal '(2013 4 16) (meetup:meetup 4 2013 :tuesday :teenth))))
 
-(define-test sunteenth-of-may-2013
-  (assert-equal '(2013 5 19) (meetup:meetup 5 2013 :sunday :teenth)))
-(define-test sunteenth-of-june-2013
-  (assert-equal '(2013 6 16) (meetup:meetup 6 2013 :sunday :teenth)))
-(define-test sunteenth-of-october-2013
-  (assert-equal '(2013 10 13) (meetup:meetup 10 2013 :sunday :teenth)))
+(test tuesteenth-of-august-2013
+ (is (equal '(2013 8 13) (meetup:meetup 8 2013 :tuesday :teenth))))
 
-(define-test first-monday-of-march-2013
-  (assert-equal '(2013 3 4) (meetup:meetup 3 2013 :monday :first)))
-(define-test first-monday-of-april-2013
-  (assert-equal '(2013 4 1) (meetup:meetup 4 2013 :monday :first)))
+(test wednesteenth-of-january-2013
+ (is (equal '(2013 1 16) (meetup:meetup 1 2013 :wednesday :teenth))))
 
-(define-test first-tuesday-of-may-2013
-  (assert-equal '(2013 5 7) (meetup:meetup 5 2013 :tuesday :first)))
-(define-test first-tuesday-of-june-2013
-  (assert-equal '(2013 6 4) (meetup:meetup 6 2013 :tuesday :first)))
+(test wednesteenth-of-february-2013
+ (is (equal '(2013 2 13) (meetup:meetup 2 2013 :wednesday :teenth))))
 
-(define-test first-wednesday-of-july-2013
-  (assert-equal '(2013 7 3) (meetup:meetup 7 2013 :wednesday :first)))
-(define-test first-wednesday-of-august-2013
-  (assert-equal '(2013 8 7) (meetup:meetup 8 2013 :wednesday :first)))
+(test wednesteenth-of-june-2013
+ (is (equal '(2013 6 19) (meetup:meetup 6 2013 :wednesday :teenth))))
 
-(define-test first-thursday-of-september-2013
-  (assert-equal '(2013 9 5) (meetup:meetup 9 2013 :thursday :first)))
-(define-test first-thursday-of-october-2013
-  (assert-equal '(2013 10 3) (meetup:meetup 10 2013 :thursday :first)))
+(test thursteenth-of-may-2013
+ (is (equal '(2013 5 16) (meetup:meetup 5 2013 :thursday :teenth))))
 
-(define-test first-friday-of-november-2013
-  (assert-equal '(2013 11 1) (meetup:meetup 11 2013 :friday :first)))
-(define-test first-friday-of-december-2013
-  (assert-equal '(2013 12 6) (meetup:meetup 12 2013 :friday :first)))
+(test thursteenth-of-june-2013
+ (is (equal '(2013 6 13) (meetup:meetup 6 2013 :thursday :teenth))))
 
-(define-test first-saturday-of-january-2013
-  (assert-equal '(2013 1 5) (meetup:meetup 1 2013 :saturday :first)))
-(define-test first-saturday-of-january-2013
-  (assert-equal '(2013 2 2) (meetup:meetup 2 2013 :saturday :first)))
+(test thursteenth-of-september-2013
+ (is (equal '(2013 9 19) (meetup:meetup 9 2013 :thursday :teenth))))
 
-(define-test first-sunday-of-march-2013
-  (assert-equal '(2013 3 3) (meetup:meetup 3 2013 :sunday :first)))
-(define-test first-sunday-of-april-2013
-  (assert-equal '(2013 4 7) (meetup:meetup 4 2013 :sunday :first)))
+(test friteenth-of-april-2013
+ (is (equal '(2013 4 19) (meetup:meetup 4 2013 :friday :teenth))))
 
-(define-test second-monday-of-march-2013
-  (assert-equal '(2013 3 11) (meetup:meetup 3 2013 :monday :second)))
-(define-test second-monday-of-april-2013
-  (assert-equal '(2013 4 8) (meetup:meetup 4 2013 :monday :second)))
+(test friteenth-of-august-2013
+ (is (equal '(2013 8 16) (meetup:meetup 8 2013 :friday :teenth))))
 
-(define-test second-tuesday-of-may-2013
-  (assert-equal '(2013 5 14) (meetup:meetup 5 2013 :tuesday :second)))
-(define-test second-tuesday-of-june-2013
-  (assert-equal '(2013 6 11) (meetup:meetup 6 2013 :tuesday :second)))
+(test friteenth-of-september-2013
+ (is (equal '(2013 9 13) (meetup:meetup 9 2013 :friday :teenth))))
 
-(define-test second-wednesday-of-july-2013
-  (assert-equal '(2013 7 10) (meetup:meetup 7 2013 :wednesday :second)))
-(define-test second-wednesday-of-august-2013
-  (assert-equal '(2013 8 14) (meetup:meetup 8 2013 :wednesday :second)))
+(test saturteenth-of-february-2013
+ (is (equal '(2013 2 16) (meetup:meetup 2 2013 :saturday :teenth))))
 
-(define-test second-thursday-of-september-2013
-  (assert-equal '(2013 9 12) (meetup:meetup 9 2013 :thursday :second)))
-(define-test second-thursday-of-october-2013
-  (assert-equal '(2013 10 10) (meetup:meetup 10 2013 :thursday :second)))
+(test saturteenth-of-april-2013
+ (is (equal '(2013 4 13) (meetup:meetup 4 2013 :saturday :teenth))))
 
-(define-test second-friday-of-november-2013
-  (assert-equal '(2013 11 8) (meetup:meetup 11 2013 :friday :second)))
-(define-test second-friday-of-december-2013
-  (assert-equal '(2013 12 13) (meetup:meetup 12 2013 :friday :second)))
+(test saturteenth-of-october-2013
+ (is (equal '(2013 10 19) (meetup:meetup 10 2013 :saturday :teenth))))
 
-(define-test second-saturday-of-january-2013
-  (assert-equal '(2013 1 12) (meetup:meetup 1 2013 :saturday :second)))
-(define-test second-saturday-of-february-2013
-  (assert-equal '(2013 2 9) (meetup:meetup 2 2013 :saturday :second)))
+(test sunteenth-of-may-2013
+ (is (equal '(2013 5 19) (meetup:meetup 5 2013 :sunday :teenth))))
 
-(define-test second-sunday-of-march-2013
-  (assert-equal '(2013 3 10) (meetup:meetup 3 2013 :sunday :second)))
-(define-test second-sunday-of-april-2013
-  (assert-equal '(2013 4 14) (meetup:meetup 4 2013 :sunday :second)))
+(test sunteenth-of-june-2013
+ (is (equal '(2013 6 16) (meetup:meetup 6 2013 :sunday :teenth))))
 
-(define-test third-monday-of-march-2013
-  (assert-equal '(2013 3 18) (meetup:meetup 3 2013 :monday :third)))
-(define-test third-monday-of-april-2013
-  (assert-equal '(2013 4 15) (meetup:meetup 4 2013 :monday :third)))
+(test sunteenth-of-october-2013
+ (is (equal '(2013 10 13) (meetup:meetup 10 2013 :sunday :teenth))))
 
-(define-test third-tuesday-of-may-2013
-  (assert-equal '(2013 5 21) (meetup:meetup 5 2013 :tuesday :third)))
-(define-test third-tuesday-of-june-2013
-  (assert-equal '(2013 6 18) (meetup:meetup 6 2013 :tuesday :third)))
+(test first-monday-of-march-2013
+ (is (equal '(2013 3 4) (meetup:meetup 3 2013 :monday :first))))
 
-(define-test third-wednesday-of-july-2013
-  (assert-equal '(2013 7 17) (meetup:meetup 7 2013 :wednesday :third)))
-(define-test third-wednesday-of-august-2013
-  (assert-equal '(2013 8 21) (meetup:meetup 8 2013 :wednesday :third)))
+(test first-monday-of-april-2013
+ (is (equal '(2013 4 1) (meetup:meetup 4 2013 :monday :first))))
 
-(define-test third-thursday-of-september-2013
-  (assert-equal '(2013 9 19) (meetup:meetup 9 2013 :thursday :third)))
-(define-test third-thursday-of-october-2013
-  (assert-equal '(2013 10 17) (meetup:meetup 10 2013 :thursday :third)))
+(test first-tuesday-of-may-2013
+ (is (equal '(2013 5 7) (meetup:meetup 5 2013 :tuesday :first))))
 
-(define-test third-friday-of-november-2013
-  (assert-equal '(2013 11 15) (meetup:meetup 11 2013 :friday :third)))
-(define-test third-friday-of-december-2013
-  (assert-equal '(2013 12 20) (meetup:meetup 12 2013 :friday :third)))
+(test first-tuesday-of-june-2013
+ (is (equal '(2013 6 4) (meetup:meetup 6 2013 :tuesday :first))))
 
-(define-test third-saturday-of-january-2013
-  (assert-equal '(2013 1 19) (meetup:meetup 1 2013 :saturday :third)))
-(define-test third-saturday-of-february-2013
-  (assert-equal '(2013 2 16) (meetup:meetup 2 2013 :saturday :third)))
+(test first-wednesday-of-july-2013
+ (is (equal '(2013 7 3) (meetup:meetup 7 2013 :wednesday :first))))
 
-(define-test third-sunday-of-march-2013
-  (assert-equal '(2013 3 17) (meetup:meetup 3 2013 :sunday :third)))
-(define-test third-sunday-of-april-2013
-  (assert-equal '(2013 4 21) (meetup:meetup 4 2013 :sunday :third)))
+(test first-wednesday-of-august-2013
+ (is (equal '(2013 8 7) (meetup:meetup 8 2013 :wednesday :first))))
 
-(define-test fourth-monday-of-march-2013
-  (assert-equal '(2013 3 25) (meetup:meetup 3 2013 :monday :fourth)))
-(define-test fourth-monday-of-april-2013
-  (assert-equal '(2013 4 22) (meetup:meetup 4 2013 :monday :fourth)))
+(test first-thursday-of-september-2013
+ (is (equal '(2013 9 5) (meetup:meetup 9 2013 :thursday :first))))
 
-(define-test fourth-tuesday-of-may-2013
-  (assert-equal '(2013 5 28) (meetup:meetup 5 2013 :tuesday :fourth)))
-(define-test fourth-tuesday-of-june-2013
-  (assert-equal '(2013 6 25) (meetup:meetup 6 2013 :tuesday :fourth)))
+(test first-thursday-of-october-2013
+ (is (equal '(2013 10 3) (meetup:meetup 10 2013 :thursday :first))))
 
-(define-test fourth-wednesday-of-july-2013
-  (assert-equal '(2013 7 24) (meetup:meetup 7 2013 :wednesday :fourth)))
-(define-test fourth-wednesday-of-august-2013
-  (assert-equal '(2013 8 28) (meetup:meetup 8 2013 :wednesday :fourth)))
+(test first-friday-of-november-2013
+ (is (equal '(2013 11 1) (meetup:meetup 11 2013 :friday :first))))
 
-(define-test fourth-thursday-of-september-2013
-  (assert-equal '(2013 9 26) (meetup:meetup 9 2013 :thursday :fourth)))
-(define-test fourth-thursday-of-october-2013
-  (assert-equal '(2013 10 24) (meetup:meetup 10 2013 :thursday :fourth)))
+(test first-friday-of-december-2013
+ (is (equal '(2013 12 6) (meetup:meetup 12 2013 :friday :first))))
 
-(define-test fourth-friday-of-november-2013
-  (assert-equal '(2013 11 22) (meetup:meetup 11 2013 :friday :fourth)))
-(define-test fourth-friday-of-december-2013
-  (assert-equal '(2013 12 27) (meetup:meetup 12 2013 :friday :fourth)))
+(test first-saturday-of-january-2013
+ (is (equal '(2013 1 5) (meetup:meetup 1 2013 :saturday :first))))
 
-(define-test fourth-saturday-of-january-2013
-  (assert-equal '(2013 1 26) (meetup:meetup 1 2013 :saturday :fourth)))
-(define-test fourth-saturday-of-february-2013
-  (assert-equal '(2013 2 23) (meetup:meetup 2 2013 :saturday :fourth)))
+(test first-saturday-of-january-2013
+ (is (equal '(2013 2 2) (meetup:meetup 2 2013 :saturday :first))))
 
-(define-test fourth-sunday-of-march-2013
-  (assert-equal '(2013 3 24) (meetup:meetup 3 2013 :sunday :fourth)))
-(define-test fourth-sunday-of-april-2013
-  (assert-equal '(2013 4 28) (meetup:meetup 4 2013 :sunday :fourth)))
+(test first-sunday-of-march-2013
+ (is (equal '(2013 3 3) (meetup:meetup 3 2013 :sunday :first))))
 
-(define-test last-monday-of-march-2013
-  (assert-equal '(2013 3 25) (meetup:meetup 3 2013 :monday :last)))
-(define-test last-monday-of-april-2013
-  (assert-equal '(2013 4 29) (meetup:meetup 4 2013 :monday :last)))
+(test first-sunday-of-april-2013
+ (is (equal '(2013 4 7) (meetup:meetup 4 2013 :sunday :first))))
 
-(define-test last-tuesday-of-may-2013
-  (assert-equal '(2013 5 28) (meetup:meetup 5 2013 :tuesday :last)))
-(define-test last-tuesday-of-june-2013
-  (assert-equal '(2013 6 25) (meetup:meetup 6 2013 :tuesday :last)))
+(test second-monday-of-march-2013
+ (is (equal '(2013 3 11) (meetup:meetup 3 2013 :monday :second))))
 
-(define-test last-wednesday-of-july-2013
-  (assert-equal '(2013 7 31) (meetup:meetup 7 2013 :wednesday :last)))
-(define-test last-wednesday-of-august-2013
-  (assert-equal '(2013 8 28) (meetup:meetup 8 2013 :wednesday :last)))
+(test second-monday-of-april-2013
+ (is (equal '(2013 4 8) (meetup:meetup 4 2013 :monday :second))))
 
-(define-test last-thursday-of-september-2013
-  (assert-equal '(2013 9 26) (meetup:meetup 9 2013 :thursday :last)))
-(define-test last-thursday-of-october-2013
-  (assert-equal '(2013 10 31) (meetup:meetup 10 2013 :thursday :last)))
+(test second-tuesday-of-may-2013
+ (is (equal '(2013 5 14) (meetup:meetup 5 2013 :tuesday :second))))
 
-(define-test last-friday-of-november-2013
-  (assert-equal '(2013 11 29) (meetup:meetup 11 2013 :friday :last)))
-(define-test last-friday-of-december-2013
-  (assert-equal '(2013 12 27) (meetup:meetup 12 2013 :friday :last)))
+(test second-tuesday-of-june-2013
+ (is (equal '(2013 6 11) (meetup:meetup 6 2013 :tuesday :second))))
 
-(define-test last-saturday-of-january-2013
-  (assert-equal '(2013 1 26) (meetup:meetup 1 2013 :saturday :last)))
-(define-test last-saturday-of-february-2013
-  (assert-equal '(2013 2 23) (meetup:meetup 2 2013 :saturday :last)))
+(test second-wednesday-of-july-2013
+ (is (equal '(2013 7 10) (meetup:meetup 7 2013 :wednesday :second))))
 
-(define-test last-sunday-of-march-2013
-  (assert-equal '(2013 3 31) (meetup:meetup 3 2013 :sunday :last)))
-(define-test last-sunday-of-april-2013
-  (assert-equal '(2013 4 28) (meetup:meetup 4 2013 :sunday :last)))
+(test second-wednesday-of-august-2013
+ (is (equal '(2013 8 14) (meetup:meetup 8 2013 :wednesday :second))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :meetup-test))
+(test second-thursday-of-september-2013
+ (is (equal '(2013 9 12) (meetup:meetup 9 2013 :thursday :second))))
+
+(test second-thursday-of-october-2013
+ (is (equal '(2013 10 10) (meetup:meetup 10 2013 :thursday :second))))
+
+(test second-friday-of-november-2013
+ (is (equal '(2013 11 8) (meetup:meetup 11 2013 :friday :second))))
+
+(test second-friday-of-december-2013
+ (is (equal '(2013 12 13) (meetup:meetup 12 2013 :friday :second))))
+
+(test second-saturday-of-january-2013
+ (is (equal '(2013 1 12) (meetup:meetup 1 2013 :saturday :second))))
+
+(test second-saturday-of-february-2013
+ (is (equal '(2013 2 9) (meetup:meetup 2 2013 :saturday :second))))
+
+(test second-sunday-of-march-2013
+ (is (equal '(2013 3 10) (meetup:meetup 3 2013 :sunday :second))))
+
+(test second-sunday-of-april-2013
+ (is (equal '(2013 4 14) (meetup:meetup 4 2013 :sunday :second))))
+
+(test third-monday-of-march-2013
+ (is (equal '(2013 3 18) (meetup:meetup 3 2013 :monday :third))))
+
+(test third-monday-of-april-2013
+ (is (equal '(2013 4 15) (meetup:meetup 4 2013 :monday :third))))
+
+(test third-tuesday-of-may-2013
+ (is (equal '(2013 5 21) (meetup:meetup 5 2013 :tuesday :third))))
+
+(test third-tuesday-of-june-2013
+ (is (equal '(2013 6 18) (meetup:meetup 6 2013 :tuesday :third))))
+
+(test third-wednesday-of-july-2013
+ (is (equal '(2013 7 17) (meetup:meetup 7 2013 :wednesday :third))))
+
+(test third-wednesday-of-august-2013
+ (is (equal '(2013 8 21) (meetup:meetup 8 2013 :wednesday :third))))
+
+(test third-thursday-of-september-2013
+ (is (equal '(2013 9 19) (meetup:meetup 9 2013 :thursday :third))))
+
+(test third-thursday-of-october-2013
+ (is (equal '(2013 10 17) (meetup:meetup 10 2013 :thursday :third))))
+
+(test third-friday-of-november-2013
+ (is (equal '(2013 11 15) (meetup:meetup 11 2013 :friday :third))))
+
+(test third-friday-of-december-2013
+ (is (equal '(2013 12 20) (meetup:meetup 12 2013 :friday :third))))
+
+(test third-saturday-of-january-2013
+ (is (equal '(2013 1 19) (meetup:meetup 1 2013 :saturday :third))))
+
+(test third-saturday-of-february-2013
+ (is (equal '(2013 2 16) (meetup:meetup 2 2013 :saturday :third))))
+
+(test third-sunday-of-march-2013
+ (is (equal '(2013 3 17) (meetup:meetup 3 2013 :sunday :third))))
+
+(test third-sunday-of-april-2013
+ (is (equal '(2013 4 21) (meetup:meetup 4 2013 :sunday :third))))
+
+(test fourth-monday-of-march-2013
+ (is (equal '(2013 3 25) (meetup:meetup 3 2013 :monday :fourth))))
+
+(test fourth-monday-of-april-2013
+ (is (equal '(2013 4 22) (meetup:meetup 4 2013 :monday :fourth))))
+
+(test fourth-tuesday-of-may-2013
+ (is (equal '(2013 5 28) (meetup:meetup 5 2013 :tuesday :fourth))))
+
+(test fourth-tuesday-of-june-2013
+ (is (equal '(2013 6 25) (meetup:meetup 6 2013 :tuesday :fourth))))
+
+(test fourth-wednesday-of-july-2013
+ (is (equal '(2013 7 24) (meetup:meetup 7 2013 :wednesday :fourth))))
+
+(test fourth-wednesday-of-august-2013
+ (is (equal '(2013 8 28) (meetup:meetup 8 2013 :wednesday :fourth))))
+
+(test fourth-thursday-of-september-2013
+ (is (equal '(2013 9 26) (meetup:meetup 9 2013 :thursday :fourth))))
+
+(test fourth-thursday-of-october-2013
+ (is (equal '(2013 10 24) (meetup:meetup 10 2013 :thursday :fourth))))
+
+(test fourth-friday-of-november-2013
+ (is (equal '(2013 11 22) (meetup:meetup 11 2013 :friday :fourth))))
+
+(test fourth-friday-of-december-2013
+ (is (equal '(2013 12 27) (meetup:meetup 12 2013 :friday :fourth))))
+
+(test fourth-saturday-of-january-2013
+ (is (equal '(2013 1 26) (meetup:meetup 1 2013 :saturday :fourth))))
+
+(test fourth-saturday-of-february-2013
+ (is (equal '(2013 2 23) (meetup:meetup 2 2013 :saturday :fourth))))
+
+(test fourth-sunday-of-march-2013
+ (is (equal '(2013 3 24) (meetup:meetup 3 2013 :sunday :fourth))))
+
+(test fourth-sunday-of-april-2013
+ (is (equal '(2013 4 28) (meetup:meetup 4 2013 :sunday :fourth))))
+
+(test last-monday-of-march-2013
+ (is (equal '(2013 3 25) (meetup:meetup 3 2013 :monday :last))))
+
+(test last-monday-of-april-2013
+ (is (equal '(2013 4 29) (meetup:meetup 4 2013 :monday :last))))
+
+(test last-tuesday-of-may-2013
+ (is (equal '(2013 5 28) (meetup:meetup 5 2013 :tuesday :last))))
+
+(test last-tuesday-of-june-2013
+ (is (equal '(2013 6 25) (meetup:meetup 6 2013 :tuesday :last))))
+
+(test last-wednesday-of-july-2013
+ (is (equal '(2013 7 31) (meetup:meetup 7 2013 :wednesday :last))))
+
+(test last-wednesday-of-august-2013
+ (is (equal '(2013 8 28) (meetup:meetup 8 2013 :wednesday :last))))
+
+(test last-thursday-of-september-2013
+ (is (equal '(2013 9 26) (meetup:meetup 9 2013 :thursday :last))))
+
+(test last-thursday-of-october-2013
+ (is (equal '(2013 10 31) (meetup:meetup 10 2013 :thursday :last))))
+
+(test last-friday-of-november-2013
+ (is (equal '(2013 11 29) (meetup:meetup 11 2013 :friday :last))))
+
+(test last-friday-of-december-2013
+ (is (equal '(2013 12 27) (meetup:meetup 12 2013 :friday :last))))
+
+(test last-saturday-of-january-2013
+ (is (equal '(2013 1 26) (meetup:meetup 1 2013 :saturday :last))))
+
+(test last-saturday-of-february-2013
+ (is (equal '(2013 2 23) (meetup:meetup 2 2013 :saturday :last))))
+
+(test last-sunday-of-march-2013
+ (is (equal '(2013 3 31) (meetup:meetup 3 2013 :sunday :last))))
+
+(test last-sunday-of-april-2013
+ (is (equal '(2013 4 28) (meetup:meetup 4 2013 :sunday :last))))
+
+(defun run-tests (&optional (test-or-suite 'meetup-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/meetup/meetup.lisp
+++ b/exercises/practice/meetup/meetup.lisp
@@ -1,5 +1,5 @@
 (defpackage #:meetup
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:meetup))
 
 (in-package #:meetup)

--- a/exercises/practice/meetup/meetup.lisp
+++ b/exercises/practice/meetup/meetup.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:meetup
   (:use #:common-lisp)
   (:export #:meetup))

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://rosalind.info/problems/dna/",
-  "source": "The Calculating DNA Nucleotides_problem at Rosalind",
-  "files": {
-    "test": [
+  "source_url":"http://rosalind.info/problems/dna/",
+  "source":"The Calculating DNA Nucleotides_problem at Rosalind",
+  "files":{
+    "test":[
       "nucleotide-count-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "nucleotide-count.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/nucleotide-count/nucleotide-count-test.lisp
+++ b/exercises/practice/nucleotide-count/nucleotide-count-test.lisp
@@ -1,43 +1,53 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "nucleotide-count")
+;; Ensures that nucleotide-count.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "nucleotide-count")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from nucleotide-count and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:nucleotide-count-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:nucleotide-count-test)
 
+;; Define and enter a new FiveAM test-suite
+(def-suite* nucleotide-count-suite)
+
 (defun make-hash (kvs)
-  (reduce
-   #'(lambda (h kv) (setf (gethash (first kv) h) (second kv)) h)
-   kvs
-   :initial-value (make-hash-table)))
+  (reduce #'(lambda (h kv) (setf (gethash (first kv) h) (second kv)) h) kvs
+          :initial-value (make-hash-table)))
 
-(define-test empty-dna-strand-has-no-adenine
-  (assert-equal 0 (nucleotide-count:dna-count #\A "")))
+(test empty-dna-strand-has-no-adenine
+ (is (equal 0 (nucleotide-count:dna-count #\A ""))))
 
-(define-test empty-dna-strand-has-no-nucleotides
-  (assert-equalp (make-hash '((#\A 0) (#\T 0) (#\C 0) (#\G 0)))
-      (nucleotide-count:nucleotide-counts "")))
+(test empty-dna-strand-has-no-nucleotides
+ (is
+  (equalp (make-hash '((#\A 0) (#\T 0) (#\C 0) (#\G 0)))
+          (nucleotide-count:nucleotide-counts ""))))
 
-(define-test repetitive-cytosine-gets-counted
-  (assert-equal 5 (nucleotide-count:dna-count #\C "CCCCC")))
+(test repetitive-cytosine-gets-counted
+ (is (equal 5 (nucleotide-count:dna-count #\C "CCCCC"))))
 
-(define-test repetitive-sequence-has-only-guanine
-  (assert-equalp (make-hash '((#\A 0) (#\T 0) (#\C 0) (#\G 8)))
-      (nucleotide-count:nucleotide-counts "GGGGGGGG")))
+(test repetitive-sequence-has-only-guanine
+ (is
+  (equalp (make-hash '((#\A 0) (#\T 0) (#\C 0) (#\G 8)))
+          (nucleotide-count:nucleotide-counts "GGGGGGGG"))))
 
-(define-test counts-only-thymine
-  (assert-equal 1 (nucleotide-count:dna-count #\T "GGGGGTAACCCGG")))
+(test counts-only-thymine
+ (is (equal 1 (nucleotide-count:dna-count #\T "GGGGGTAACCCGG"))))
 
-(define-test validates-nucleotides
-  (assert-error 'nucleotide-count:invalid-nucleotide (nucleotide-count:dna-count #\X "GACT")))
+(test validates-nucleotides
+ (signals nucleotide-count:invalid-nucleotide
+  (nucleotide-count:dna-count #\X "GACT")))
 
-(define-test counts-all-nucleotides
-  (assert-equalp (make-hash '((#\A 20) (#\T 21) (#\G 17) (#\C 12)))
-      (nucleotide-count:nucleotide-counts
-       "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")))
+(test counts-all-nucleotides
+ (is
+  (equalp (make-hash '((#\A 20) (#\T 21) (#\G 17) (#\C 12)))
+          (nucleotide-count:nucleotide-counts
+           "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :nucleotide-count-test))
+(defun run-tests (&optional (test-or-suite 'nucleotide-count-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/nucleotide-count/nucleotide-count.lisp
+++ b/exercises/practice/nucleotide-count/nucleotide-count.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:nucleotide-count
   (:use #:common-lisp)
   (:export #:dna-count #:nucleotide-counts #:invalid-nucleotide))

--- a/exercises/practice/nucleotide-count/nucleotide-count.lisp
+++ b/exercises/practice/nucleotide-count/nucleotide-count.lisp
@@ -1,5 +1,5 @@
 (defpackage #:nucleotide-count
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:dna-count #:nucleotide-counts #:invalid-nucleotide))
 
 (in-package #:nucleotide-count)

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html",
-  "source": "Pascal's Triangle at Wolfram Math World",
-  "files": {
-    "test": [
+  "source_url":"http://mathworld.wolfram.com/PascalsTriangle.html",
+  "source":"Pascal's Triangle at Wolfram Math World",
+  "files":{
+    "test":[
       "pascals-triangle-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "pascals-triangle.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/pascals-triangle/pascals-triangle-test.lisp
+++ b/exercises/practice/pascals-triangle/pascals-triangle-test.lisp
@@ -1,34 +1,33 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "pascals-triangle")
+;; Ensures that pascals-triangle.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "pascals-triangle")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from pascals-triangle and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:pascals-triangle-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
+
+;; Enter the testing package
 (in-package #:pascals-triangle-test)
 
-(define-test zero-rows
-    (assert-equal '()
-                  (pascals-triangle:rows 0)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* pascals-triangle-suite)
 
-(define-test single-row
-    (assert-equal '((1))
-                  (pascals-triangle:rows 1)))
+(test zero-rows (is (equal 'nil (pascals-triangle:rows 0))))
 
-(define-test two-rows
-    (assert-equal '((1) (1 1))
-                  (pascals-triangle:rows 2)))
+(test single-row (is (equal '((1)) (pascals-triangle:rows 1))))
 
-(define-test three-rows
-    (assert-equal '((1) (1 1) (1 2 1))
-                  (pascals-triangle:rows 3)))
+(test two-rows (is (equal '((1) (1 1)) (pascals-triangle:rows 2))))
 
-(define-test four-rows
-    (assert-equal '((1) (1 1) (1 2 1) (1 3 3 1))
-                  (pascals-triangle:rows 4)))
+(test three-rows (is (equal '((1) (1 1) (1 2 1)) (pascals-triangle:rows 3))))
 
-(define-test negative-rows
-    (assert-equal '()
-                  (pascals-triangle:rows -1)))
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :pascals-triange-test))
+(test four-rows
+ (is (equal '((1) (1 1) (1 2 1) (1 3 3 1)) (pascals-triangle:rows 4))))
+
+(test negative-rows (is (equal 'nil (pascals-triangle:rows -1))))
+
+(defun run-tests (&optional (test-or-suite 'pascals-triangle-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/pascals-triangle/pascals-triangle.lisp
+++ b/exercises/practice/pascals-triangle/pascals-triangle.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:pascals-triangle
   (:use #:cl)
   (:export #:rows))

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://shop.oreilly.com/product/0636920029687.do",
-  "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
-  "files": {
-    "test": [
+  "source_url":"http://shop.oreilly.com/product/0636920029687.do",
+  "source":"Taken from Chapter 2 of Functional Thinking by Neal Ford.",
+  "files":{
+    "test":[
       "perfect-numbers-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "perfect-numbers.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/perfect-numbers/perfect-numbers-test.lisp
+++ b/exercises/practice/perfect-numbers/perfect-numbers-test.lisp
@@ -1,56 +1,54 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "perfect-numbers")
+;; Ensures that perfect-numbers.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "perfect-numbers")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from perfect-numbers and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:perfect-numbers-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:perfect-numbers-test)
 
+;; Define and enter a new FiveAM test-suite
+(def-suite* perfect-numbers-suite)
 
-;; Perfect numbers tests:
-(define-test smallest-perfect-number
-  (assert-equal "perfect" (perfect-numbers:classify 6)))
+(test smallest-perfect-number
+ (is (equal "perfect" (perfect-numbers:classify 6))))
 
-(define-test medium-perfect-number
-  (assert-equal "perfect" (perfect-numbers:classify 28)))
+(test medium-perfect-number
+ (is (equal "perfect" (perfect-numbers:classify 28))))
 
-(define-test large-perfect-number
-  (assert-equal "perfect" (perfect-numbers:classify 33550336)))
+(test large-perfect-number
+ (is (equal "perfect" (perfect-numbers:classify 33550336))))
 
+(test smallest-abundant-number
+ (is (equal "abundant" (perfect-numbers:classify 12))))
 
-;; Abundant numbers tests:
-(define-test smallest-abundant-number
-  (assert-equal "abundant" (perfect-numbers:classify 12)))
+(test medium-abundant-number
+ (is (equal "abundant" (perfect-numbers:classify 30))))
 
-(define-test medium-abundant-number
-  (assert-equal "abundant" (perfect-numbers:classify 30)))
+(test large-abundant-number
+ (is (equal "abundant" (perfect-numbers:classify 33550335))))
 
-(define-test large-abundant-number
-  (assert-equal "abundant" (perfect-numbers:classify 33550335)))
+(test smallest-prime-deficient-number
+ (is (equal "deficient" (perfect-numbers:classify 2))))
 
+(test smallest-non-prime-deficient-number
+ (is (equal "deficient" (perfect-numbers:classify 1))))
 
-;; Deficient numbers tests:
-(define-test smallest-prime-deficient-number
-  (assert-equal "deficient" (perfect-numbers:classify 2)))
+(test medium-deficient-number
+ (is (equal "deficient" (perfect-numbers:classify 32))))
 
-(define-test smallest-non-prime-deficient-number
-  (assert-equal "deficient" (perfect-numbers:classify 1)))
+(test large-deficient-number
+ (is (equal "deficient" (perfect-numbers:classify 33550337))))
 
-(define-test medium-deficient-number
-  (assert-equal "deficient" (perfect-numbers:classify 32)))
+(test undefinded-0 (is (equal nil (perfect-numbers:classify 0))))
 
-(define-test large-deficient-number
-  (assert-equal "deficient" (perfect-numbers:classify 33550337)))
+(test undefined-negative (is (equal nil (perfect-numbers:classify -3))))
 
-
-;; Undefined values of classify tests:
-(define-test undefinded-0
-  (assert-equal NIL (perfect-numbers:classify 0)))
-
-(define-test undefined-negative
-  (assert-equal NIL (perfect-numbers:classify -3)))
-
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(defun run-tests (&optional (test-or-suite 'perfect-numbers-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/perfect-numbers/perfect-numbers.lisp
+++ b/exercises/practice/perfect-numbers/perfect-numbers.lisp
@@ -1,5 +1,5 @@
 (defpackage #:perfect-numbers
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:classify))
 
 (in-package #:perfect-numbers)

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html",
-  "source": "Event Manager by JumpstartLab",
-  "files": {
-    "test": [
+  "source_url":"http://tutorials.jumpstartlab.com/projects/eventmanager.html",
+  "source":"Event Manager by JumpstartLab",
+  "files":{
+    "test":[
       "phone-number-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "phone-number.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/phone-number/phone-number-test.lisp
+++ b/exercises/practice/phone-number/phone-number-test.lisp
@@ -1,36 +1,43 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "phone-number")
+;; Ensures that phone-number.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "phone-number")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from phone-number and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:phone-number-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:phone-number-test)
 
-(define-test cleans-number
-  (assert-equal "1234567890" (phone-number:numbers "(123) 456-7890")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* phone-number-suite)
 
-(define-test cleans-number-with-dots
-  (assert-equal "1234567890" (phone-number:numbers "123.456.7890")))
+(test cleans-number
+ (is (equal "1234567890" (phone-number:numbers "(123) 456-7890"))))
 
-(define-test valid-when-11-digits-and-first-is-1
-  (assert-equal "1234567890" (phone-number:numbers "11234567890")))
+(test cleans-number-with-dots
+ (is (equal "1234567890" (phone-number:numbers "123.456.7890"))))
 
-(define-test invalid-when-11-digits
-  (assert-equal "0000000000" (phone-number:numbers "21234567890")))
+(test valid-when-11-digits-and-first-is-1
+ (is (equal "1234567890" (phone-number:numbers "11234567890"))))
 
-(define-test invalid-when-9-digits
-  (assert-equal "0000000000" (phone-number:numbers "123456789")))
+(test invalid-when-11-digits
+ (is (equal "0000000000" (phone-number:numbers "21234567890"))))
 
-(define-test area-code
-  (assert-equal "123" (phone-number:area-code "1234567890")))
+(test invalid-when-9-digits
+ (is (equal "0000000000" (phone-number:numbers "123456789"))))
 
-(define-test pretty-print
-  (assert-equal "(123) 456-7890" (phone-number:pretty-print "1234567890")))
+(test area-code (is (equal "123" (phone-number:area-code "1234567890"))))
 
-(define-test pretty-print-with-full-us-phone-number
-  (assert-equal "(123) 456-7890" (phone-number:pretty-print "11234567890")))
+(test pretty-print
+ (is (equal "(123) 456-7890" (phone-number:pretty-print "1234567890"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :phone-number-test))
+(test pretty-print-with-full-us-phone-number
+ (is (equal "(123) 456-7890" (phone-number:pretty-print "11234567890"))))
+
+(defun run-tests (&optional (test-or-suite 'phone-number-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/phone-number/phone-number.lisp
+++ b/exercises/practice/phone-number/phone-number.lisp
@@ -1,5 +1,5 @@
 (defpackage #:phone-number
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:numbers #:area-code #:pretty-print))
 
 (in-package #:phone-number)

--- a/exercises/practice/phone-number/phone-number.lisp
+++ b/exercises/practice/phone-number/phone-number.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:phone-number
   (:use #:common-lisp)
   (:export #:numbers #:area-code #:pretty-print))

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata",
-  "source": "The Prime Factors Kata by Uncle Bob",
-  "files": {
-    "test": [
+  "source_url":"http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata",
+  "source":"The Prime Factors Kata by Uncle Bob",
+  "files":{
+    "test":[
       "prime-factors-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "prime-factors.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/prime-factors/prime-factors-test.lisp
+++ b/exercises/practice/prime-factors/prime-factors-test.lisp
@@ -1,79 +1,72 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "prime-factors")
+;; Ensures that prime-factors.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "prime-factors")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from prime-factors and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:prime-factors-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:prime-factors-test)
 
-(define-test one
-  (assert-equal '() (prime-factors:factors-of 1)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* prime-factors-suite)
 
-(define-test two
-  (assert-equal '(2) (prime-factors:factors-of 2)))
+(test one (is (equal 'nil (prime-factors:factors-of 1))))
 
-(define-test three
-  (assert-equal '(3) (prime-factors:factors-of 3)))
+(test two (is (equal '(2) (prime-factors:factors-of 2))))
 
-(define-test four
-  (assert-equal '(2 2) (prime-factors:factors-of 4)))
+(test three (is (equal '(3) (prime-factors:factors-of 3))))
 
-(define-test six
-  (assert-equal '(2 3) (sort (prime-factors:factors-of 6) #'<)))
+(test four (is (equal '(2 2) (prime-factors:factors-of 4))))
 
-(define-test eight
-  (assert-equal '(2 2 2) (prime-factors:factors-of 8)))
+(test six (is (equal '(2 3) (sort (prime-factors:factors-of 6) #'<))))
 
-(define-test nine
-  (assert-equal '(3 3) (prime-factors:factors-of 9)))
+(test eight (is (equal '(2 2 2) (prime-factors:factors-of 8))))
 
-(define-test twenty-seven
-  (assert-equal '(3 3 3) (prime-factors:factors-of 27)))
+(test nine (is (equal '(3 3) (prime-factors:factors-of 9))))
 
-(define-test six-hundred-twenty-five
-  (assert-equal '(5 5 5 5) (prime-factors:factors-of 625)))
+(test twenty-seven (is (equal '(3 3 3) (prime-factors:factors-of 27))))
 
-(define-test a-large-number
-  (assert-equal '(5 17 23 461)
-                (sort (prime-factors:factors-of 901255) #'<)))
+(test six-hundred-twenty-five
+ (is (equal '(5 5 5 5) (prime-factors:factors-of 625))))
 
-(define-test a-huge-number
-  (assert-equal '(11 9539 894119)
-                (sort (prime-factors:factors-of 93819012551) #'<)))
+(test a-large-number
+ (is (equal '(5 17 23 461) (sort (prime-factors:factors-of 901255) #'<))))
 
-(define-test triple-squares-number
-  (assert-equal '(2 2 5 5 7 7)
-                (sort (prime-factors:factors-of 4900) #'<)))
+(test a-huge-number
+ (is
+  (equal '(11 9539 894119) (sort (prime-factors:factors-of 93819012551) #'<))))
 
-(define-test mersenne-composite-1
-  (assert-equal '(23 89)
-                (sort (prime-factors:factors-of 2047) #'<)))
+(test triple-squares-number
+ (is (equal '(2 2 5 5 7 7) (sort (prime-factors:factors-of 4900) #'<))))
 
-(define-test fermat-composite-1
-  (assert-equal '(641 6700417)
-                (sort (prime-factors:factors-of 4294967297) #'<)))
+(test mersenne-composite-1
+ (is (equal '(23 89) (sort (prime-factors:factors-of 2047) #'<))))
 
-(define-test weak-probable-prime
-  (assert-equal '(11 31)
-                (sort (prime-factors:factors-of 341) #'<)))
+(test fermat-composite-1
+ (is (equal '(641 6700417) (sort (prime-factors:factors-of 4294967297) #'<))))
 
-(define-test strong-probable-prime
-  (assert-equal '(7 31 73)
-                (sort (prime-factors:factors-of 15841) #'<)))
+(test weak-probable-prime
+ (is (equal '(11 31) (sort (prime-factors:factors-of 341) #'<))))
 
-(define-test carmichael-small-1
-  (assert-equal '(3 11 17)
-                (sort (prime-factors:factors-of 561) #'<)))
+(test strong-probable-prime
+ (is (equal '(7 31 73) (sort (prime-factors:factors-of 15841) #'<))))
 
-(define-test carmichael-small-2
-  (assert-equal '(11 13 17 31)
-                (sort (prime-factors:factors-of 75361) #'<)))
+(test carmichael-small-1
+ (is (equal '(3 11 17) (sort (prime-factors:factors-of 561) #'<))))
 
-(define-test pseudoprime-smallish
-  (assert-equal '(1303 16927 157543)
-                (sort (prime-factors:factors-of 3474749660383) #'<)))
+(test carmichael-small-2
+ (is (equal '(11 13 17 31) (sort (prime-factors:factors-of 75361) #'<))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :prime-factors-test))
+(test pseudoprime-smallish
+ (is
+  (equal '(1303 16927 157543)
+         (sort (prime-factors:factors-of 3474749660383) #'<))))
+
+(defun run-tests (&optional (test-or-suite 'prime-factors-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/prime-factors/prime-factors.lisp
+++ b/exercises/practice/prime-factors/prime-factors.lisp
@@ -1,5 +1,5 @@
 (defpackage #:prime-factors
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export :factors-of))
 
 (in-package #:prime-factors)

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz",
-  "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
-  "files": {
-    "test": [
+  "source_url":"https://en.wikipedia.org/wiki/Fizz_buzz",
+  "source":"A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
+  "files":{
+    "test":[
       "raindrops-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "raindrops.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/raindrops/raindrops-test.lisp
+++ b/exercises/practice/raindrops/raindrops-test.lisp
@@ -1,72 +1,50 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "raindrops")
+;; Ensures that raindrops.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "raindrops")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from raindrops and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:raindrops-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:raindrops-test)
 
-(define-test test-1
-    (assert-equal "1"
-                  (raindrops:convert 1)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* raindrops-suite)
 
-(define-test test-3
-    (assert-equal "Pling"
-                  (raindrops:convert 3)))
+(test test-1 (is (equal "1" (raindrops:convert 1))))
 
-(define-test test-5
-    (assert-equal "Plang"
-                  (raindrops:convert 5)))
+(test test-3 (is (equal "Pling" (raindrops:convert 3))))
 
-(define-test test-7
-    (assert-equal "Plong"
-                  (raindrops:convert 7)))
+(test test-5 (is (equal "Plang" (raindrops:convert 5))))
 
-(define-test test-6
-    (assert-equal "Pling"
-                  (raindrops:convert 6)))
+(test test-7 (is (equal "Plong" (raindrops:convert 7))))
 
-(define-test test-9
-    (assert-equal "Pling"
-                  (raindrops:convert 9)))
+(test test-6 (is (equal "Pling" (raindrops:convert 6))))
 
-(define-test test-10
-    (assert-equal "Plang"
-                  (raindrops:convert 10)))
+(test test-9 (is (equal "Pling" (raindrops:convert 9))))
 
-(define-test test-15
-    (assert-equal "PlingPlang"
-                  (raindrops:convert 15)))
+(test test-10 (is (equal "Plang" (raindrops:convert 10))))
 
-(define-test test-21
-    (assert-equal "PlingPlong"
-                  (raindrops:convert 21)))
+(test test-15 (is (equal "PlingPlang" (raindrops:convert 15))))
 
-(define-test test-25
-    (assert-equal "Plang"
-                  (raindrops:convert 25)))
+(test test-21 (is (equal "PlingPlong" (raindrops:convert 21))))
 
-(define-test test-35
-    (assert-equal "PlangPlong"
-                  (raindrops:convert 35)))
+(test test-25 (is (equal "Plang" (raindrops:convert 25))))
 
-(define-test test-49
-    (assert-equal "Plong"
-                  (raindrops:convert 49)))
+(test test-35 (is (equal "PlangPlong" (raindrops:convert 35))))
 
-(define-test test-52
-    (assert-equal "52"
-                  (raindrops:convert 52)))
+(test test-49 (is (equal "Plong" (raindrops:convert 49))))
 
-(define-test test-105
-    (assert-equal "PlingPlangPlong"
-                  (raindrops:convert 105)))
+(test test-52 (is (equal "52" (raindrops:convert 52))))
 
-(define-test test-12121
-    (assert-equal "12121"
-                  (raindrops:convert 12121)))
+(test test-105 (is (equal "PlingPlangPlong" (raindrops:convert 105))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :raindrops-test))
+(test test-12121 (is (equal "12121" (raindrops:convert 12121))))
+
+(defun run-tests (&optional (test-or-suite 'raindrops-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/raindrops/raindrops.lisp
+++ b/exercises/practice/raindrops/raindrops.lisp
@@ -1,5 +1,5 @@
 (defpackage #:raindrops
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:convert))
 
 (in-package #:raindrops)

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
-  "source": "Hyperphysics",
-  "files": {
-    "test": [
+  "source_url":"http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
+  "source":"Hyperphysics",
+  "files":{
+    "test":[
       "rna-transcription-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "rna-transcription.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/rna-transcription/rna-transcription-test.lisp
+++ b/exercises/practice/rna-transcription/rna-transcription-test.lisp
@@ -1,30 +1,38 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "rna-transcription")
+;; Ensures that rna-transcription.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "rna-transcription")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from rna-transcription and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage :rna-transcription-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:rna-transcription-test)
 
-(define-test transcribes-cytidine-to-guanosine
-  (assert-equal "G" (rna-transcription:to-rna "C")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* rna-transcription-suite)
 
-(define-test transcribes-guanosine-to-cytidine
-  (assert-equal "C" (rna-transcription:to-rna "G")))
+(test transcribes-cytidine-to-guanosine
+ (is (equal "G" (rna-transcription:to-rna "C"))))
 
-(define-test transcribes-adenosine-to-uracile
-  (assert-equal "U" (rna-transcription:to-rna "A")))
+(test transcribes-guanosine-to-cytidine
+ (is (equal "C" (rna-transcription:to-rna "G"))))
 
-(define-test it-transcribes-thymidine-to-adenosine
-  (assert-equal "A" (rna-transcription:to-rna "T")))
+(test transcribes-adenosine-to-uracile
+ (is (equal "U" (rna-transcription:to-rna "A"))))
 
-(define-test it-transcribes-all-nucleotides
-  (assert-equal "UGCACCAGAAUU" (rna-transcription:to-rna "ACGTGGTCTTAA")))
+(test it-transcribes-thymidine-to-adenosine
+ (is (equal "A" (rna-transcription:to-rna "T"))))
 
-(define-test it-validates-dna-strands
-  (assert-error 'error (rna-transcription:to-rna "XCGFGGTDTTAA")))
+(test it-transcribes-all-nucleotides
+ (is (equal "UGCACCAGAAUU" (rna-transcription:to-rna "ACGTGGTCTTAA"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :rna-transcription-test))
+(test it-validates-dna-strands
+ (signals error (rna-transcription:to-rna "XCGFGGTDTTAA")))
+
+(defun run-tests (&optional (test-or-suite 'rna-transcription-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/rna-transcription/rna-transcription.lisp
+++ b/exercises/practice/rna-transcription/rna-transcription.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:rna-transcription
   (:use #:cl)
   (:export #:to-rna))

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,16 +1,15 @@
 {
-  "v2": true,
-  "source": "A debugging session with Paul Blackwell at gSchool.",
-  "files": {
-    "test": [
+  "source":"A debugging session with Paul Blackwell at gSchool.",
+  "files":{
+    "test":[
       "robot-name-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "robot-name.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/robot-name/robot-name-test.lisp
+++ b/exercises/practice/robot-name/robot-name-test.lisp
@@ -1,40 +1,47 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "robot-name")
+;; Ensures that robot-name.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "robot-name")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from robot-name and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:robot-name-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:robot-name-test)
 
+;; Define and enter a new FiveAM test-suite
+(def-suite* robot-name-suite)
+
 (defun is-upper-alpha-p (c) (char<= #\A c #\Z))
+
 (defun is-digit-p (c) (char-not-greaterp #\0 c #\9))
 
-(defparameter *robbie* (robot-name:build-robot))
-(defparameter *clutz* (robot-name:build-robot))
+(test name-matches-expected-pattern
+  (let* ((robbie (robot-name:build-robot))
+         (name (robot-name:robot-name robbie)))
+   (is (= (length name) 5))
+   (is (every #'is-upper-alpha-p (subseq name 0 2)))
+   (is (every #'is-digit-p (subseq name 2 5)))))
 
-(define-test name-matches-expected-pattern
-  (let ((name (robot-name:robot-name *robbie*)))
-    (assert-true (= (length name) 5))
-    (assert-true (every #'is-upper-alpha-p (subseq name 0 2)))
-    (assert-true (every #'is-digit-p (subseq name 2 5)))))
+(test name-is-persistent
+  (let ((robbie (robot-name:build-robot)))
+   (is (equal (robot-name:robot-name robbie) (robot-name:robot-name robbie)))))
 
-(define-test name-is-persistent
-  (assert-equal (robot-name:robot-name *robbie*) (robot-name:robot-name *robbie*)))
+(test different-robots-have-different-names
+  (let ((robbie (robot-name:build-robot))
+        (clutz (robot-name:build-robot)))
+   (is (not (equal (robot-name:robot-name clutz)
+                   (robot-name:robot-name robbie))))))
 
-(define-test different-robots-have-different-names
-  (assert-equality (complement #'equal)
-      (robot-name:robot-name *clutz*)
-      (robot-name:robot-name *robbie*)))
+(test name-can-be-reset
+ (let* ((robot (robot-name:build-robot))
+        (original-name (robot-name:robot-name robot)))
+   (robot-name:reset-name robot)
+   (is (not (equal (robot-name:robot-name robot) original-name)))))
 
-(define-test name-can-be-reset
-  (let* ((robot (robot-name:build-robot))
-         (original-name (robot-name:robot-name robot)))
-    (robot-name:reset-name robot)
-    (assert-equality (complement #'equal)
-        (robot-name:robot-name robot)
-        original-name)))
-
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :robot-name-test))
+(defun run-tests (&optional (test-or-suite 'robot-name-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/robot-name/robot-name.lisp
+++ b/exercises/practice/robot-name/robot-name.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:robot-name
   (:use #:common-lisp)
   (:export #:build-robot #:robot-name #:reset-name))

--- a/exercises/practice/robot-name/robot-name.lisp
+++ b/exercises/practice/robot-name/robot-name.lisp
@@ -1,5 +1,5 @@
 (defpackage #:robot-name
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:build-robot #:robot-name #:reset-name))
 
 (in-package #:robot-name)

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "",
-  "source": "Inspired by an interview question at a famous company.",
-  "files": {
-    "test": [
+  "source_url":"",
+  "source":"Inspired by an interview question at a famous company.",
+  "files":{
+    "test":[
       "robot-simulator-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "robot-simulator.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/robot-simulator/robot-simulator-test.lisp
+++ b/exercises/practice/robot-simulator/robot-simulator-test.lisp
@@ -1,118 +1,160 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "robot-simulator")
+;; Ensures that robot-simulator.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "robot-simulator")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from robot-simulator and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:robot-simulator-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:robot-simulator-test)
 
-(define-test robots-are-created-with-defaults
-  (let ((robot (robot-simulator:make-robot)))
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+north+ (robot-simulator:robot-bearing robot))))
+;; Define and enter a new FiveAM test-suite
+(def-suite* robot-simulator-suite)
 
-(define-test negative-coordinates-allowed
-  (let ((robot (robot-simulator:make-robot :position '(-1 . -1) :bearing robot-simulator:+south+)))
-    (assert-equal '(-1 . -1) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+south+ (robot-simulator:robot-bearing robot))))
+(test robots-are-created-with-defaults
+ (let ((robot (robot-simulator:make-robot)))
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+north+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-right-north-to-east
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+north+)))
-    (robot-simulator:execute-sequence robot "R")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+east+ (robot-simulator:robot-bearing robot))))
+(test negative-coordinates-allowed
+ (let ((robot
+        (robot-simulator:make-robot :position '(-1 . -1) :bearing
+         robot-simulator:+south+)))
+   (is (equal '(-1 . -1) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+south+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-right-east-to-south
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+east+)))
-    (robot-simulator:execute-sequence robot "R")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+south+ (robot-simulator:robot-bearing robot))))
+(test turn-right-north-to-east
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+north+)))
+   (robot-simulator:execute-sequence robot "R")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+east+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-right-south-to-west
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+south+)))
-    (robot-simulator:execute-sequence robot "R")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+west+ (robot-simulator:robot-bearing robot))))
+(test turn-right-east-to-south
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+east+)))
+   (robot-simulator:execute-sequence robot "R")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+south+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-right-west-to-north
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+west+)))
-    (robot-simulator:execute-sequence robot "R")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+north+ (robot-simulator:robot-bearing robot))))
+(test turn-right-south-to-west
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+south+)))
+   (robot-simulator:execute-sequence robot "R")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+west+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-left-north-to-west
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+north+)))
-    (robot-simulator:execute-sequence robot "L")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+west+ (robot-simulator:robot-bearing robot))))
+(test turn-right-west-to-north
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+west+)))
+   (robot-simulator:execute-sequence robot "R")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+north+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-left-west-to-south
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+west+)))
-    (robot-simulator:execute-sequence robot "L")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+south+ (robot-simulator:robot-bearing robot))))
+(test turn-left-north-to-west
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+north+)))
+   (robot-simulator:execute-sequence robot "L")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+west+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-left-south-to-east
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+south+)))
-    (robot-simulator:execute-sequence robot "L")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+east+ (robot-simulator:robot-bearing robot))))
+(test turn-left-west-to-south
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+west+)))
+   (robot-simulator:execute-sequence robot "L")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+south+ (robot-simulator:robot-bearing robot)))))
 
-(define-test turn-left-east-to-north
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+east+)))
-    (robot-simulator:execute-sequence robot "L")
-    (assert-equal '(0 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+north+ (robot-simulator:robot-bearing robot))))
+(test turn-left-south-to-east
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+south+)))
+   (robot-simulator:execute-sequence robot "L")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+east+ (robot-simulator:robot-bearing robot)))))
 
-(define-test advance-increments-y-when-facing-north
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+north+)))
-    (robot-simulator:execute-sequence robot "A")
-    (assert-equal '(0 . 1) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+north+ (robot-simulator:robot-bearing robot))))
+(test turn-left-east-to-north
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+east+)))
+   (robot-simulator:execute-sequence robot "L")
+   (is (equal '(0 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+north+ (robot-simulator:robot-bearing robot)))))
 
-(define-test advance-decrements-y-when-facing-north
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+south+)))
-    (robot-simulator:execute-sequence robot "A")
-    (assert-equal '(0 . -1) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+south+ (robot-simulator:robot-bearing robot))))
+(test advance-increments-y-when-facing-north
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+north+)))
+   (robot-simulator:execute-sequence robot "A")
+   (is (equal '(0 . 1) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+north+ (robot-simulator:robot-bearing robot)))))
 
-(define-test advance-increments-x-when-facing-east
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+east+)))
-    (robot-simulator:execute-sequence robot "A")
-    (assert-equal '(1 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+east+ (robot-simulator:robot-bearing robot))))
+(test advance-decrements-y-when-facing-north
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+south+)))
+   (robot-simulator:execute-sequence robot "A")
+   (is (equal '(0 . -1) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+south+ (robot-simulator:robot-bearing robot)))))
 
-(define-test advance-decrements-x-when-facing-west
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+west+)))
-    (robot-simulator:execute-sequence robot "A")
-    (assert-equal '(-1 . 0) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+west+ (robot-simulator:robot-bearing robot))))
+(test advance-increments-x-when-facing-east
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+east+)))
+   (robot-simulator:execute-sequence robot "A")
+   (is (equal '(1 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+east+ (robot-simulator:robot-bearing robot)))))
 
-(define-test move-east-and-north-readme
-  (let ((robot (robot-simulator:make-robot :position '(7 . 3) :bearing robot-simulator:+north+)))
-    (robot-simulator:execute-sequence robot "RAALAL")
-    (assert-equal '(9 . 4) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+west+ (robot-simulator:robot-bearing robot))))
+(test advance-decrements-x-when-facing-west
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+west+)))
+   (robot-simulator:execute-sequence robot "A")
+   (is (equal '(-1 . 0) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+west+ (robot-simulator:robot-bearing robot)))))
 
-(define-test move-west-and-north
-  (let ((robot (robot-simulator:make-robot :position '(0 . 0) :bearing robot-simulator:+north+)))
-    (robot-simulator:execute-sequence robot "LAAARALA")
-    (assert-equal '(-4 . 1) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+west+ (robot-simulator:robot-bearing robot))))
+(test move-east-and-north-readme
+ (let ((robot
+        (robot-simulator:make-robot :position '(7 . 3) :bearing
+         robot-simulator:+north+)))
+   (robot-simulator:execute-sequence robot "RAALAL")
+   (is (equal '(9 . 4) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+west+ (robot-simulator:robot-bearing robot)))))
 
-(define-test move-west-and-south
-  (let ((robot (robot-simulator:make-robot :position '(2 . -7) :bearing robot-simulator:+east+)))
-    (robot-simulator:execute-sequence robot "RRAAAAALA")
-    (assert-equal '(-3 . -8) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+south+ (robot-simulator:robot-bearing robot))))
+(test move-west-and-north
+ (let ((robot
+        (robot-simulator:make-robot :position '(0 . 0) :bearing
+         robot-simulator:+north+)))
+   (robot-simulator:execute-sequence robot "LAAARALA")
+   (is (equal '(-4 . 1) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+west+ (robot-simulator:robot-bearing robot)))))
 
-(define-test move-east-and-north
-  (let ((robot (robot-simulator:make-robot :position '(8 . 4) :bearing robot-simulator:+south+)))
-    (robot-simulator:execute-sequence robot "LAAARRRALLLL")
-    (assert-equal '(11 . 5) (robot-simulator:robot-position robot))
-    (assert-equal robot-simulator:+north+ (robot-simulator:robot-bearing robot))))
+(test move-west-and-south
+ (let ((robot
+        (robot-simulator:make-robot :position '(2 . -7) :bearing
+         robot-simulator:+east+)))
+   (robot-simulator:execute-sequence robot "RRAAAAALA")
+   (is (equal '(-3 . -8) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+south+ (robot-simulator:robot-bearing robot)))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :robot-simulator-test))
+(test move-east-and-north
+ (let ((robot
+        (robot-simulator:make-robot :position '(8 . 4) :bearing
+         robot-simulator:+south+)))
+   (robot-simulator:execute-sequence robot "LAAARRRALLLL")
+   (is (equal '(11 . 5) (robot-simulator:robot-position robot)))
+   (is (equal robot-simulator:+north+ (robot-simulator:robot-bearing robot)))))
+
+(defun run-tests (&optional (test-or-suite 'robot-simulator-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/robot-simulator/robot-simulator.lisp
+++ b/exercises/practice/robot-simulator/robot-simulator.lisp
@@ -1,5 +1,5 @@
 (defpackage #:robot-simulator
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:+north+ #:+east+ #:+south+ #:+west+ #:execute-sequence
            #:robot #:robot-position #:robot-bearing #:make-robot))
 

--- a/exercises/practice/robot-simulator/robot-simulator.lisp
+++ b/exercises/practice/robot-simulator/robot-simulator.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:robot-simulator
   (:use #:common-lisp)
   (:export #:+north+ #:+east+ #:+south+ #:+west+ #:execute-sequence

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,17 +1,10 @@
 {
-  "v2": true,
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals",
   "source": "The Roman Numeral Kata",
   "files": {
-    "test": [
-      "roman-numerals-test.lisp"
-    ],
-    "solution": [
-      "roman-numerals.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["roman-numerals-test.lisp"],
+    "solution": ["roman-numerals.lisp"],
+    "example": [".meta/example.lisp"]
   },
   "authors": []
 }

--- a/exercises/practice/roman-numerals/roman-numerals-test.lisp
+++ b/exercises/practice/roman-numerals/roman-numerals-test.lisp
@@ -1,66 +1,74 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "roman-numerals")
+;; Ensures that roman-numerals.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "roman-numerals")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from roman-numerals and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:roman-numerals-test
-  (:use #:cl #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:roman-numerals-test)
 
-(define-test test-1
-  (assert-equal "I" (roman-numerals:romanize 1)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* roman-numerals-suite)
 
-(define-test test-2
-  (assert-equal "II" (roman-numerals:romanize 2)))
+(test test-1
+  (is (string= "I" (roman-numerals:romanize 1))))
 
-(define-test test-3
-  (assert-equal "III" (roman-numerals:romanize 3)))
+(test test-2
+  (is (string= "II" (roman-numerals:romanize 2))))
 
-(define-test test-4
-  (assert-equal "IV" (roman-numerals:romanize 4)))
+(test test-3
+  (is (string= "III" (roman-numerals:romanize 3))))
 
-(define-test test-5
-  (assert-equal "V" (roman-numerals:romanize 5)))
+(test test-4
+  (is (string= "IV" (roman-numerals:romanize 4))))
 
-(define-test test-6
-  (assert-equal "VI" (roman-numerals:romanize 6)))
+(test test-5
+  (is (string= "V" (roman-numerals:romanize 5))))
 
-(define-test test-9
-  (assert-equal "IX" (roman-numerals:romanize 9)))
+(test test-6
+  (is (string= "VI" (roman-numerals:romanize 6))))
 
-(define-test test-27
-  (assert-equal "XXVII" (roman-numerals:romanize 27)))
+(test test-9
+  (is (string= "IX" (roman-numerals:romanize 9))))
 
-(define-test test-48
-  (assert-equal "XLVIII" (roman-numerals:romanize 48)))
+(test test-27
+  (is (string= "XXVII" (roman-numerals:romanize 27))))
 
-(define-test test-59
-  (assert-equal "LIX" (roman-numerals:romanize 59)))
+(test test-48
+  (is (string= "XLVIII" (roman-numerals:romanize 48))))
 
-(define-test test-93
-  (assert-equal "XCIII" (roman-numerals:romanize 93)))
+(test test-59
+  (is (string= "LIX" (roman-numerals:romanize 59))))
 
-(define-test test-141
-  (assert-equal "CXLI" (roman-numerals:romanize 141)))
+(test test-93
+  (is (string= "XCIII" (roman-numerals:romanize 93))))
 
-(define-test test-163
-  (assert-equal "CLXIII" (roman-numerals:romanize 163)))
+(test test-141
+  (is (string= "CXLI" (roman-numerals:romanize 141))))
 
-(define-test test-402
-  (assert-equal "CDII" (roman-numerals:romanize 402)))
+(test test-163
+  (is (string= "CLXIII" (roman-numerals:romanize 163))))
 
-(define-test test-575
-  (assert-equal "DLXXV" (roman-numerals:romanize 575)))
+(test test-402
+  (is (string= "CDII" (roman-numerals:romanize 402))))
 
-(define-test test-911
-  (assert-equal "CMXI" (roman-numerals:romanize 911)))
+(test test-575
+  (is (string= "DLXXV" (roman-numerals:romanize 575))))
 
-(define-test test-1024
-  (assert-equal "MXXIV" (roman-numerals:romanize 1024)))
+(test test-911
+  (is (string= "CMXI" (roman-numerals:romanize 911))))
 
-(define-test test-3000
-  (assert-equal "MMM" (roman-numerals:romanize 3000)))
+(test test-1024
+  (is (string= "MXXIV" (roman-numerals:romanize 1024))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :roman-numerals-test))
+(test test-3000
+  (is (string= "MMM" (roman-numerals:romanize 3000))))
+
+(defun run-tests (&optional (test-or-suite 'roman-numerals-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/roman-numerals/roman-numerals.lisp
+++ b/exercises/practice/roman-numerals/roman-numerals.lisp
@@ -1,8 +1,8 @@
-(defpackage #:roman
+(defpackage #:roman-numerals
   (:use #:cl)
   (:export #:romanize))
 
-(in-package #:roman)
+(in-package #:roman-numerals)
 
 (defun romanize (number)
   "Returns the Roman numeral representation for a given number."

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://github.com/rchatley/extreme_startup",
-  "source": "Inspired by the Extreme Startup game",
-  "files": {
-    "test": [
+  "source_url":"https://github.com/rchatley/extreme_startup",
+  "source":"Inspired by the Extreme Startup game",
+  "files":{
+    "test":[
       "scrabble-score-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "scrabble-score.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/scrabble-score/scrabble-score-test.lisp
+++ b/exercises/practice/scrabble-score/scrabble-score-test.lisp
@@ -1,37 +1,42 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "scrabble-score")
+;; Ensures that scrabble-score.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "scrabble-score")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from scrabble-score and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:scrabble-score-test
-  (:use #:cl #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:scrabble-score-test)
 
-(define-test no-word-has-zero-score
-  (assert-equal 0 (scrabble-score:score-word "")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* scrabble-score-suite)
 
-(define-test whitespace-only-also-has-zero-score
-  (assert-equal 0 (scrabble-score:score-word
-                   (concatenate 'string '(#\Space #\Newline)))))
+(test no-word-has-zero-score (is (equal 0 (scrabble-score:score-word ""))))
 
-(define-test scores-small-word
-  (assert-equal 1 (scrabble-score:score-word "a")))
+(test whitespace-only-also-has-zero-score
+ (is
+  (equal 0 (scrabble-score:score-word (concatenate 'string '(#\  #\Newline))))))
 
-(define-test is-case-insensitive
-  (assert-equal 1 (scrabble-score:score-word "A")))
+(test scores-small-word (is (equal 1 (scrabble-score:score-word "a"))))
 
-(define-test scores-a-slightly-bigger-word
-  (assert-equal 2 (scrabble-score:score-word "at")))
+(test is-case-insensitive (is (equal 1 (scrabble-score:score-word "A"))))
 
-(define-test scores-a-middle-of-the-road-word
-  (assert-equal 6 (scrabble-score:score-word "street")))
+(test scores-a-slightly-bigger-word
+ (is (equal 2 (scrabble-score:score-word "at"))))
 
-(define-test scores-a-peculiar-word
-  (assert-equal 22 (scrabble-score:score-word "quirky")))
+(test scores-a-middle-of-the-road-word
+ (is (equal 6 (scrabble-score:score-word "street"))))
 
-(define-test scores-a-very-long-word
-  (assert-equal 27 (scrabble-score:score-word "UNEXCLUSIVENESS")))
+(test scores-a-peculiar-word
+ (is (equal 22 (scrabble-score:score-word "quirky"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :scrabble-score-test))
+(test scores-a-very-long-word
+ (is (equal 27 (scrabble-score:score-word "UNEXCLUSIVENESS"))))
+
+(defun run-tests (&optional (test-or-suite 'scrabble-score-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes",
-  "source": "Sieve of Eratosthenes at Wikipedia",
-  "files": {
-    "test": [
+  "source_url":"http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes",
+  "source":"Sieve of Eratosthenes at Wikipedia",
+  "files":{
+    "test":[
       "sieve-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "sieve.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/sieve/sieve-test.lisp
+++ b/exercises/practice/sieve/sieve-test.lisp
@@ -1,47 +1,42 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "sieve")
+;; Ensures that sieve.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "sieve")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from sieve and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:sieve-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:sieve-test)
 
-(define-test no-primes-under-two
-  (assert-equal '()
-                (sieve:primes-to 1)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* sieve-suite)
 
-(define-test find-first-prime
-  (assert-equal '(2)
-                (sieve:primes-to 2)))
+(test no-primes-under-two (is (equal 'nil (sieve:primes-to 1))))
 
-(define-test find-primes-up-to-10
-  (assert-equal '(2 3 5 7)
-                (sieve:primes-to 10)))
+(test find-first-prime (is (equal '(2) (sieve:primes-to 2))))
 
-(define-test limit-is-prime
-  (assert-equal '(2 3 5 7 11 13)
-                (sieve:primes-to 13)))
+(test find-primes-up-to-10 (is (equal '(2 3 5 7) (sieve:primes-to 10))))
 
-(define-test primes-below-1000
-  (let ((primes-below-1000
-         '(  2   3   5   7  11  13  17  19  23  29  31  37
-           41  43  47  53  59  61  67  71  73  79  83  89
-           97 101 103 107 109 113 127 131 137 139 149 151
-           157 163 167 173 179 181 191 193 197 199 211 223
-           227 229 233 239 241 251 257 263 269 271 277 281
-           283 293 307 311 313 317 331 337 347 349 353 359
-           367 373 379 383 389 397 401 409 419 421 431 433
-           439 443 449 457 461 463 467 479 487 491 499 503
-           509 521 523 541 547 557 563 569 571 577 587 593
-           599 601 607 613 617 619 631 641 643 647 653 659
-           661 673 677 683 691 701 709 719 727 733 739 743
-           751 757 761 769 773 787 797 809 811 821 823 827
-           829 839 853 857 859 863 877 881 883 887 907 911
-           919 929 937 941 947 953 967 971 977 983 991 997)))
-    (assert-equal primes-below-1000
-                  (sieve:primes-to 1000))))
+(test limit-is-prime (is (equal '(2 3 5 7 11 13) (sieve:primes-to 13))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :sieve-test))
+(test primes-below-1000
+ (let ((primes-below-1000
+        '(2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89
+          97 101 103 107 109 113 127 131 137 139 149 151 157 163 167 173 179
+          181 191 193 197 199 211 223 227 229 233 239 241 251 257 263 269 271
+          277 281 283 293 307 311 313 317 331 337 347 349 353 359 367 373 379
+          383 389 397 401 409 419 421 431 433 439 443 449 457 461 463 467 479
+          487 491 499 503 509 521 523 541 547 557 563 569 571 577 587 593 599
+          601 607 613 617 619 631 641 643 647 653 659 661 673 677 683 691 701
+          709 719 727 733 739 743 751 757 761 769 773 787 797 809 811 821 823
+          827 829 839 853 857 859 863 877 881 883 887 907 911 919 929 937 941
+          947 953 967 971 977 983 991 997)))
+   (is (equal primes-below-1000 (sieve:primes-to 1000)))))
+
+(defun run-tests (&optional (test-or-suite 'sieve-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,17 +1,10 @@
 {
-  "v2": true,
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "files": {
-    "test": [
-      "space-age-test.lisp"
-    ],
-    "solution": [
-      "space-age.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["space-age-test.lisp"],
+    "solution": ["space-age.lisp"],
+    "example": [".meta/example.lisp"]
   },
   "authors": []
 }

--- a/exercises/practice/space-age/space-age-test.lisp
+++ b/exercises/practice/space-age/space-age-test.lisp
@@ -1,55 +1,62 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "space-age")
+;; Ensures that space-age.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "space-age")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from space-age and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:space-age-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:space-age-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* space-age-suite)
 
 (defun rounds-to (expected actual)
   (flet ((to-2-places (n) (/ (fround (* 100 n)))))
-    (assert-equal (to-2-places expected)
-			(to-2-places actual))))
+    (is (= (to-2-places expected) (to-2-places actual)))))
 
-(define-test age-in-earth-years
+(test age-in-earth-years
   (rounds-to 31.69 (space-age:on-earth 1000000001)))
 
-(define-test age-in-mercury-years
+(test age-in-mercury-years
   (let ((seconds 2134835688))
     (rounds-to 67.65 (space-age:on-earth seconds))
     (rounds-to 280.88 (space-age:on-mercury seconds))))
 
-(define-test age-in-venus-years
+(test age-in-venus-years
   (let ((seconds 189839836))
     (rounds-to 6.02 (space-age:on-earth seconds))
     (rounds-to 9.78 (space-age:on-venus seconds))))
 
-(define-test age-on-mars
+(test age-on-mars
   (let ((seconds 2329871239))
     (rounds-to 73.83 (space-age:on-earth seconds))
     (rounds-to 39.25 (space-age:on-mars seconds))))
 
-(define-test age-on-jupiter
+(test age-on-jupiter
   (let ((seconds 901876382))
     (rounds-to 28.58 (space-age:on-earth seconds))
     (rounds-to 2.41 (space-age:on-jupiter seconds))))
 
-(define-test age-on-saturn
+(test age-on-saturn
   (let ((seconds 3000000000))
     (rounds-to 95.06 (space-age:on-earth seconds))
     (rounds-to 3.23 (space-age:on-saturn seconds))))
 
-(define-test age-on-uranus
+(test age-on-uranus
   (let ((seconds 3210123456))
     (rounds-to 101.72 (space-age:on-earth seconds))
     (rounds-to 1.21 (space-age:on-uranus seconds))))
 
-(define-test age-on-neptune
+(test age-on-neptune
   (let ((seconds 8210123456))
     (rounds-to 260.16 (space-age:on-earth seconds))
     (rounds-to 1.58 (space-age:on-neptune seconds))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :space-age-test))
+(defun run-tests (&optional (test-or-suite 'space-age-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/space-age/space-age.lisp
+++ b/exercises/practice/space-age/space-age.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:space-age
   (:use #:cl)
   (:export #:on-mercury

--- a/exercises/practice/space-age/space-age.lisp
+++ b/exercises/practice/space-age/space-age.lisp
@@ -1,6 +1,14 @@
 (in-package #:cl-user)
 (defpackage #:space-age
-  (:use #:common-lisp))
+  (:use #:cl)
+  (:export #:on-mercury
+           #:on-venus
+           #:on-earth
+           #:on-mars
+           #:on-jupiter
+           #:on-saturn
+           #:on-uranus
+           #:on-neptune))
 
 (in-package #:space-age)
 

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "https://twitter.com/jeg2",
-  "source": "Conversation with James Edward Gray II",
-  "files": {
-    "test": [
+  "source_url":"https://twitter.com/jeg2",
+  "source":"Conversation with James Edward Gray II",
+  "files":{
+    "test":[
       "strain-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "strain.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/strain/strain.lisp
+++ b/exercises/practice/strain/strain.lisp
@@ -1,5 +1,5 @@
 (defpackage #:strain
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:keep #:discard))
 
 (in-package #:strain)

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,15 +1,14 @@
 {
-  "v2": true,
-  "files": {
-    "test": [
+  "files":{
+    "test":[
       "sublist-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "sublist.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/sublist/sublist-test.lisp
+++ b/exercises/practice/sublist/sublist-test.lisp
@@ -1,87 +1,70 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "sublist")
+;; Ensures that sublist.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "sublist")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from sublist and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:sublist-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:sublist-test)
 
+;; Define and enter a new FiveAM test-suite
+(def-suite* sublist-suite)
 
-;; Equal lists tests:
-(define-test empty-lists
-  (assert-equal :equal (sublist:sublist (list)
-                                         (list))))
+(test empty-lists (is (equal :equal (sublist:sublist (list) (list)))))
 
-(define-test list-equals-itself
-  (assert-equal :equal (sublist:sublist (list 1 2 3)
-                                         (list 1 2 3))))
+(test list-equals-itself
+ (is (equal :equal (sublist:sublist (list 1 2 3) (list 1 2 3)))))
 
+(test different-lists
+ (is (equal :unequal (sublist:sublist (list 1 2 3) (list 2 3 4)))))
 
-;; Unequal lists tests:
-(define-test different-lists
-  (assert-equal :unequal (sublist:sublist (list 1 2 3)
-                                           (list 2 3 4))))
+(test first-list-missing-element-from-second-list
+ (is (equal :unequal (sublist:sublist (list 1 3) (list 1 2 3)))))
 
-(define-test first-list-missing-element-from-second-list
-  (assert-equal :unequal (sublist:sublist (list 1 3)
-                                           (list 1 2 3))))
+(test second-list-missing-element-from-first-list
+ (is (equal :unequal (sublist:sublist (list 1 2 3) (list 1 3)))))
 
-(define-test second-list-missing-element-from-first-list
-  (assert-equal :unequal (sublist:sublist (list 1 2 3)
-                                           (list 1 3))))
+(test order-matters-to-a-lists
+ (is (equal :unequal (sublist:sublist (list 1 2 3) (list 3 2 1)))))
 
-(define-test order-matters-to-a-lists
-  (assert-equal :unequal (sublist:sublist (list 1 2 3)
-                                           (list 3 2 1))))
+(test same-digits-different-numbers
+ (is (equal :unequal (sublist:sublist (list 1 0 1) (list 10 1)))))
 
-(define-test same-digits-different-numbers
-  (assert-equal :unequal (sublist:sublist (list 1 0 1)
-                                           (list 10 1))))
+(test empty-list-within-non-empty-list
+ (is (equal :sublist (sublist:sublist (list) (list 1 2 3)))))
 
-;; Sublist lists tests:
-(define-test empty-list-within-non-empty-list
-  (assert-equal :sublist (sublist:sublist (list)
-                                           (list 1 2 3))))
+(test false-start
+ (is (equal :sublist (sublist:sublist (list 1 2 5) (list 0 1 2 3 1 2 5 6)))))
 
-(define-test false-start
-  (assert-equal :sublist (sublist:sublist (list 1 2 5)
-                                           (list 0 1 2 3 1 2 5 6))))
+(test consecutive
+ (is (equal :sublist (sublist:sublist (list 1 1 2) (list 0 1 1 1 2 1 2)))))
 
-(define-test consecutive
-  (assert-equal :sublist (sublist:sublist (list 1 1 2)
-                                           (list 0 1 1 1 2 1 2))))
+(test sublist-at-start
+ (is (equal :sublist (sublist:sublist (list 0 1 2) (list 0 1 2 3 4 5)))))
 
-(define-test sublist-at-start
-  (assert-equal :sublist (sublist:sublist (list 0 1 2)
-                                           (list 0 1 2 3 4 5))))
+(test sublist-in-middle
+ (is (equal :sublist (sublist:sublist (list 2 3 4) (list 0 1 2 3 4 5)))))
 
-(define-test sublist-in-middle
-  (assert-equal :sublist (sublist:sublist (list 2 3 4)
-                                           (list 0 1 2 3 4 5))))
+(test sublist-at-end
+ (is (equal :sublist (sublist:sublist (list 3 4 5) (list 0 1 2 3 4 5)))))
 
-(define-test sublist-at-end
-  (assert-equal :sublist (sublist:sublist (list 3 4 5)
-                                           (list 0 1 2 3 4 5))))
+(test not-empty-list-contains-empty-list
+ (is (equal :superlist (sublist:sublist (list 1 2 3) (list)))))
 
+(test at-start-of-superlist
+ (is (equal :superlist (sublist:sublist (list 0 1 2 3 4 5) (list 0 1 2)))))
 
-;; Superlist lists tests:
-(define-test not-empty-list-contains-empty-list
-  (assert-equal :superlist (sublist:sublist (list 1 2 3)
-                                             (list))))
+(test in-middle-of-superlist
+ (is (equal :superlist (sublist:sublist (list 0 1 2 3 4 5) (list 2 3)))))
 
-(define-test at-start-of-superlist
-  (assert-equal :superlist (sublist:sublist (list 0 1 2 3 4 5)
-                                             (list 0 1 2))))
+(test at-end-superlist
+ (is (equal :superlist (sublist:sublist (list 0 1 2 3 4 5) (list 3 4 5)))))
 
-(define-test in-middle-of-superlist
-  (assert-equal :superlist (sublist:sublist (list 0 1 2 3 4 5)
-                                             (list 2 3))))
-
-(define-test at-end-superlist
-  (assert-equal :superlist (sublist:sublist (list 0 1 2 3 4 5)
-                                             (list 3 4 5))))
-
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(defun run-tests (&optional (test-or-suite 'sublist-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/sublist/sublist.lisp
+++ b/exercises/practice/sublist/sublist.lisp
@@ -1,5 +1,5 @@
 (defpackage #:sublist
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:sublist))
 
 (in-package #:sublist)

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://rubykoans.com",
-  "source": "The Ruby Koans triangle project, parts 1 & 2",
-  "files": {
-    "test": [
+  "source_url":"http://rubykoans.com",
+  "source":"The Ruby Koans triangle project, parts 1 & 2",
+  "files":{
+    "test":[
       "triangle-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "triangle.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/triangle/triangle-test.lisp
+++ b/exercises/practice/triangle/triangle-test.lisp
@@ -1,27 +1,34 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "triangle")
+;; Ensures that triangle.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "triangle")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from triangle and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:triangle-test
-  (:use #:cl #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:triangle-test)
 
-(define-test equilateral-1
-  (assert-equal  :equilateral (triangle:triangle 2 2 2)))
-(define-test equilateral-2
-  (assert-equal  :equilateral (triangle:triangle 10 10 10)))
-(define-test isoceles-1
-  (assert-equal  :isosceles (triangle:triangle 3 4 4)))
-(define-test isoceles-2
-  (assert-equal  :isosceles (triangle:triangle 4 3 4)))
-(define-test scalene
-  (assert-equal  :scalene (triangle:triangle 3 4 5)))
-(define-test invalid-1
-  (assert-equal  :illogical (triangle:triangle 1 1 50)))
-(define-test invalid-2
-  (assert-equal  :illogical (triangle:triangle 1 2 1)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* triangle-suite)
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :triangle-test))
+(test equilateral-1 (is (equal :equilateral (triangle:triangle 2 2 2))))
+
+(test equilateral-2 (is (equal :equilateral (triangle:triangle 10 10 10))))
+
+(test isoceles-1 (is (equal :isosceles (triangle:triangle 3 4 4))))
+
+(test isoceles-2 (is (equal :isosceles (triangle:triangle 4 3 4))))
+
+(test scalene (is (equal :scalene (triangle:triangle 3 4 5))))
+
+(test invalid-1 (is (equal :illogical (triangle:triangle 1 1 50))))
+
+(test invalid-2 (is (equal :illogical (triangle:triangle 1 2 1))))
+
+(defun run-tests (&optional (test-or-suite 'triangle-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/triangle/triangle.lisp
+++ b/exercises/practice/triangle/triangle.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:triangle
   (:use #:cl)
   (:export #:triangle))

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
-  "source": "All of Computer Science",
-  "files": {
-    "test": [
+  "source_url":"http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
+  "source":"All of Computer Science",
+  "files":{
+    "test":[
       "trinary-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "trinary.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/trinary/trinary-test.lisp
+++ b/exercises/practice/trinary/trinary-test.lisp
@@ -1,43 +1,42 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "trinary")
+;; Ensures that trinary.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "trinary")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from trinary and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:trinary-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:trinary-test)
 
-(define-test trinary-1-is-decimal-1
-  (assert-equal 1 (trinary:to-decimal "1")))
+;; Define and enter a new FiveAM test-suite
+(def-suite* trinary-suite)
 
-(define-test trinary-2-is-decimal-2
-  (assert-equal 2 (trinary:to-decimal "2")))
+(test trinary-1-is-decimal-1 (is (equal 1 (trinary:to-decimal "1"))))
 
-(define-test trinary-10-is-decimal-3
-  (assert-equal 3 (trinary:to-decimal "10")))
+(test trinary-2-is-decimal-2 (is (equal 2 (trinary:to-decimal "2"))))
 
-(define-test trinary-11-is-decimal-4
-  (assert-equal 4 (trinary:to-decimal "11")))
+(test trinary-10-is-decimal-3 (is (equal 3 (trinary:to-decimal "10"))))
 
-(define-test trinary-100-is-decimal-9
-  (assert-equal 9 (trinary:to-decimal "100")))
+(test trinary-11-is-decimal-4 (is (equal 4 (trinary:to-decimal "11"))))
 
-(define-test trinary-112-is-decimal-14
-  (assert-equal 14 (trinary:to-decimal "112")))
+(test trinary-100-is-decimal-9 (is (equal 9 (trinary:to-decimal "100"))))
 
-(define-test trinary-222-is-decimal-26
+(test trinary-112-is-decimal-14 (is (equal 14 (trinary:to-decimal "112"))))
 
-  (assert-equal 26 (trinary:to-decimal "222")))
+(test trinary-222-is-decimal-26 (is (equal 26 (trinary:to-decimal "222"))))
 
-(define-test trinary-1122000120-is-decimal-32091
-  (assert-equal 32091 (trinary:to-decimal "1122000120")))
+(test trinary-1122000120-is-decimal-32091
+ (is (equal 32091 (trinary:to-decimal "1122000120"))))
 
-(define-test invalid-input-is-decimal-0
-  (assert-equal 0 (trinary:to-decimal "carrot")))
+(test invalid-input-is-decimal-0 (is (equal 0 (trinary:to-decimal "carrot"))))
 
-(define-test invalid-input-with-digits-is-decimal-0
-  (assert-equal 0 (trinary:to-decimal "0a1b2c")))
+(test invalid-input-with-digits-is-decimal-0
+ (is (equal 0 (trinary:to-decimal "0a1b2c"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :trinary-test))
+(defun run-tests (&optional (test-or-suite 'trinary-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/trinary/trinary.lisp
+++ b/exercises/practice/trinary/trinary.lisp
@@ -1,5 +1,5 @@
 (defpackage #:trinary
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:to-decimal))
 
 (in-package #:trinary)

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,17 +1,16 @@
 {
-  "v2": true,
-  "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)",
-  "source": "Wikipedia",
-  "files": {
-    "test": [
+  "source_url":"http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)",
+  "source":"Wikipedia",
+  "files":{
+    "test":[
       "twelve-days-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "twelve-days.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/twelve-days/twelve-days-test.lisp
+++ b/exercises/practice/twelve-days/twelve-days-test.lisp
@@ -1,80 +1,106 @@
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "twelve-days")
+;; Ensures that twelve-days.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "twelve-days")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from twelve-days and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:twelve-days-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
 
+;; Enter the testing package
 (in-package #:twelve-days-test)
 
-(defvar verse1  "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.")
-(defvar verse2  "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse3  "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse4  "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse5  "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse6  "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse7  "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse8  "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse9  "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse10 "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse11 "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
-(defvar verse12 "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
+;; Define and enter a new FiveAM test-suite
+(def-suite* twelve-days-suite)
 
-(defun verse-mash (&rest verses)
-  (format nil "~{~&~A~}" verses))
+(defvar verse1
+  "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.")
 
-(define-test first_day_a_partridge_in_a_pear_tree
-  (assert-equal verse1 (twelve-days:recite 1)))
+(defvar verse2
+  "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test second_day_two_turtle_doves
-  (assert-equal verse2 (twelve-days:recite 2)))
+(defvar verse3
+  "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test third_day_three_french_hens
-  (assert-equal verse3 (twelve-days:recite 3)))
+(defvar verse4
+  "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test fourth_day_four_calling_birds
-  (assert-equal verse4 (twelve-days:recite 4)))
+(defvar verse5
+  "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test fifth_day_five_gold_rings
-  (assert-equal verse5 (twelve-days:recite 5)))
+(defvar verse6
+  "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test sixth_day_six_geese_a_laying
-  (assert-equal verse6 (twelve-days:recite 6)))
+(defvar verse7
+  "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test seventh_day_seven_swans_a_swimming
-  (assert-equal verse7 (twelve-days:recite 7)))
+(defvar verse8
+  "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test eighth_day_eight_maids_a_milking
-  (assert-equal verse8 (twelve-days:recite 8)))
+(defvar verse9
+  "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test ninth_day_nine_ladies_dancing
-  (assert-equal verse9 (twelve-days:recite 9)))
+(defvar verse10
+  "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test tenth_day_ten_lords_a_leaping
-  (assert-equal verse10 (twelve-days:recite 10)))
+(defvar verse11
+  "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test eleventh_day_eleven_pipers_piping
-  (assert-equal verse11 (twelve-days:recite 11)))
+(defvar verse12
+  "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.")
 
-(define-test twelfth_day_twelve_drummers_drumming
-  (assert-equal verse12 (twelve-days:recite 12)))
+(defun verse-mash (&rest verses) (format nil "~{~&~A~}" verses))
 
-(define-test recites_first_three_verses_of_the_song
-  (assert-equal (verse-mash verse1 verse2 verse3)
-                (twelve-days:recite 1 3)))
+(test first_day_a_partridge_in_a_pear_tree
+ (is (equal verse1 (twelve-days:recite 1))))
 
-(define-test recites_three_verses_from_the_middle_of_the_song
-  (assert-equal (verse-mash verse4 verse5 verse6)
-                (twelve-days:recite 4 6)))
+(test second_day_two_turtle_doves (is (equal verse2 (twelve-days:recite 2))))
 
-(define-test recites_the_whole_song
-  (assert-equal (verse-mash verse1 verse2 verse3 verse4 verse5 verse6
-                            verse7 verse8 verse9 verse10 verse11 verse12)
-                (twelve-days:recite 1 12))
-  (assert-equal (verse-mash verse1 verse2 verse3 verse4 verse5 verse6
-                            verse7 verse8 verse9 verse10 verse11 verse12)
-                (twelve-days:recite)))
+(test third_day_three_french_hens (is (equal verse3 (twelve-days:recite 3))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all :twelve-days-test))
+(test fourth_day_four_calling_birds (is (equal verse4 (twelve-days:recite 4))))
+
+(test fifth_day_five_gold_rings (is (equal verse5 (twelve-days:recite 5))))
+
+(test sixth_day_six_geese_a_laying (is (equal verse6 (twelve-days:recite 6))))
+
+(test seventh_day_seven_swans_a_swimming
+ (is (equal verse7 (twelve-days:recite 7))))
+
+(test eighth_day_eight_maids_a_milking
+ (is (equal verse8 (twelve-days:recite 8))))
+
+(test ninth_day_nine_ladies_dancing (is (equal verse9 (twelve-days:recite 9))))
+
+(test tenth_day_ten_lords_a_leaping
+ (is (equal verse10 (twelve-days:recite 10))))
+
+(test eleventh_day_eleven_pipers_piping
+ (is (equal verse11 (twelve-days:recite 11))))
+
+(test twelfth_day_twelve_drummers_drumming
+ (is (equal verse12 (twelve-days:recite 12))))
+
+(test recites_first_three_verses_of_the_song
+ (is (equal (verse-mash verse1 verse2 verse3) (twelve-days:recite 1 3))))
+
+(test recites_three_verses_from_the_middle_of_the_song
+ (is (equal (verse-mash verse4 verse5 verse6) (twelve-days:recite 4 6))))
+
+(test recites_the_whole_song
+ (is
+  (equal
+   (verse-mash verse1 verse2 verse3 verse4 verse5 verse6 verse7 verse8 verse9
+    verse10 verse11 verse12)
+   (twelve-days:recite 1 12)))
+ (is
+  (equal
+   (verse-mash verse1 verse2 verse3 verse4 verse5 verse6 verse7 verse8 verse9
+    verse10 verse11 verse12)
+   (twelve-days:recite))))
+
+(defun run-tests (&optional (test-or-suite 'twelve-days-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/twelve-days/twelve-days.lisp
+++ b/exercises/practice/twelve-days/twelve-days.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:twelve-days
   (:use #:cl)
   (:export #:recite))

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,16 +1,15 @@
 {
-  "v2": true,
-  "source_url": "https://github.com/exercism/problem-specifications/issues/757",
-  "files": {
-    "test": [
+  "source_url":"https://github.com/exercism/problem-specifications/issues/757",
+  "files":{
+    "test":[
       "two-fer-test.lisp"
     ],
-    "solution": [
+    "solution":[
       "two-fer.lisp"
     ],
-    "example": [
+    "example":[
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors":null
 }

--- a/exercises/practice/two-fer/two-fer-test.lisp
+++ b/exercises/practice/two-fer/two-fer-test.lisp
@@ -1,40 +1,31 @@
-;;;
-;;; two-fer v1.2.0
-;;;
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "two-fer")
+;; Ensures that two-fer.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "two-fer")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from two-fer and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:two-fer-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
+
+;; Enter the testing package
 (in-package #:two-fer-test)
 
-(define-test
-    no-name-given-nil
-    (assert-equal
-     "One for you, one for me."
-     (two-fer:twofer nil)))
+;; Define and enter a new FiveAM test-suite
+(def-suite* two-fer-suite)
 
+(test no-name-given-nil
+ (is (equal "One for you, one for me." (two-fer:twofer nil))))
 
-(define-test
-  a-name-given
-  (assert-equal
-    "One for Alice, one for me."
-    (two-fer:twofer "Alice")))
+(test a-name-given
+ (is (equal "One for Alice, one for me." (two-fer:twofer "Alice"))))
 
+(test another-name-given
+ (is (equal "One for Bob, one for me." (two-fer:twofer "Bob"))))
 
-(define-test
-    another-name-given
-    (assert-equal
-     "One for Bob, one for me."
-     (two-fer:twofer "Bob")))
+(test no-name-given (is (equal "One for you, one for me." (two-fer:twofer))))
 
-(define-test
-    no-name-given
-    (assert-equal
-     "One for you, one for me."
-     (two-fer:twofer)))
-
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(defun run-tests (&optional (test-or-suite 'two-fer-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/two-fer/two-fer.lisp
+++ b/exercises/practice/two-fer/two-fer.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:two-fer
   (:use #:cl)
   (:export #:twofer))

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,16 +1,9 @@
 {
-  "v2": true,
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.",
   "files": {
-    "test": [
-      "word-count-test.lisp"
-    ],
-    "solution": [
-      "word-count.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["word-count-test.lisp"],
+    "solution": ["word-count.lisp"],
+    "example": [".meta/example.lisp"]
   },
   "authors": []
 }

--- a/exercises/practice/word-count/word-count-test.lisp
+++ b/exercises/practice/word-count/word-count-test.lisp
@@ -1,122 +1,110 @@
-;;;
-;;; word-count v1.4.0
-;;;
-;;; For each word in the input, count the number of times it appears in the
-;;; entire sentence.
-;;;
-(ql:quickload "lisp-unit")
-#-xlisp-test (load "word-count")
+;; Ensures that word-count.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "word-count")
+  (quicklisp-client:quickload :fiveam))
 
+;; Defines the testing package with symbols from word-count and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
 (defpackage #:word-count-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:fiveam)
+  (:export #:run-tests))
+
+;; Enter the testing package
 (in-package #:word-count-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* word-count-suite)
 
 (defun assert-alist-equal (expected actual)
   "The association lists must have the same length and the keys and
    values of the items must match. But the order is not
    important. Equality is tested with equal"
-  (assert-equal
-   (sort (copy-seq expected) #'string< :key #'car)
-   (sort (copy-seq actual) #'string< :key #'car)))
+  (equal (sort (copy-seq expected) #'string< :key #'car)
+         (sort (copy-seq actual) #'string< :key #'car)))
 
-(define-test
-  count-one-word
-  (assert-alist-equal
-    '(("word" . 1))
-    (word-count:count-words "word")))
+(test count-one-word
+  (is (assert-alist-equal
+       '(("word" . 1))
+       (word-count:count-words "word"))))
 
-
-(define-test
-  count-one-of-each-word
-  (assert-alist-equal
-    '(("one" . 1) ("of" . 1) ("each" . 1))
-    (word-count:count-words "one of each")))
+(test count-one-of-each-word
+  (is(assert-alist-equal
+      '(("one" . 1) ("of" . 1) ("each" . 1))
+      (word-count:count-words "one of each"))))
 
 
-(define-test
-  multiple-occurrences-of-a-word
-  (assert-alist-equal
-    '(("one" . 1) ("fish" . 4) ("two" . 1) ("red" . 1) ("blue" . 1))
-    (word-count:count-words "one fish two fish red fish blue fish")))
+(test multiple-occurrences-of-a-word
+  (is (assert-alist-equal
+       '(("one" . 1) ("fish" . 4) ("two" . 1) ("red" . 1) ("blue" . 1))
+       (word-count:count-words "one fish two fish red fish blue fish"))))
 
 
-(define-test
-  handles-cramped-lists
-  (assert-alist-equal
-    '(("one" . 1) ("two" . 1) ("three" . 1))
-    (word-count:count-words "one,two,three")))
+(test handles-cramped-lists
+  (is (assert-alist-equal
+       '(("one" . 1) ("two" . 1) ("three" . 1))
+       (word-count:count-words "one,two,three"))))
 
 
-(define-test
-  handles-expanded-lists
-  (assert-alist-equal
-    '(("one" . 1) ("two" . 1) ("three" . 1))
-    (word-count:count-words "one,
+(test handles-expanded-lists
+  (is (assert-alist-equal
+       '(("one" . 1) ("two" . 1) ("three" . 1))
+       (word-count:count-words "one,
 two,
-three")))
+three"))))
 
 
-(define-test
-  ignore-punctuation
-  (assert-alist-equal
-    '(("car" . 1) ("carpet" . 1) ("as" . 1) ("java" . 1) ("javascript" . 1))
-    (word-count:count-words "car: carpet as java: javascript!!&@$%^&")))
+(test ignore-punctuation
+  (is (assert-alist-equal
+       '(("car" . 1) ("carpet" . 1) ("as" . 1) ("java" . 1) ("javascript" . 1))
+       (word-count:count-words "car: carpet as java: javascript!!&@$%^&"))))
 
 
-(define-test
-  include-numbers
-  (assert-alist-equal
-    '(("testing" . 2) ("1" . 1) ("2" . 1))
-    (word-count:count-words "testing, 1, 2 testing")))
+(test include-numbers
+  (is (assert-alist-equal
+       '(("testing" . 2) ("1" . 1) ("2" . 1))
+       (word-count:count-words "testing, 1, 2 testing"))))
 
 
-(define-test
-  normalize-case
-  (assert-alist-equal
-    '(("go" . 3) ("stop" . 2))
-    (word-count:count-words "go Go GO Stop stop")))
+(test normalize-case
+  (is (assert-alist-equal
+       '(("go" . 3) ("stop" . 2))
+       (word-count:count-words "go Go GO Stop stop"))))
 
 
-(define-test
-  with-apostrophes
-  (assert-alist-equal
-    '(("first" . 1) ("don't" . 2) ("laugh" . 1) ("then" . 1) ("cry" . 1))
-    (word-count:count-words "First: don't laugh. Then: don't cry.")))
+(test with-apostrophes
+  (is (assert-alist-equal
+       '(("first" . 1) ("don't" . 2) ("laugh" . 1) ("then" . 1) ("cry" . 1))
+       (word-count:count-words "First: don't laugh. Then: don't cry."))))
 
 
-(define-test
-  with-quotations
-  (assert-alist-equal
-    '(("joe" . 1) ("can't" . 1) ("tell" . 1) ("between" . 1) ("large" . 2)
-      ("and" . 1))
-    (word-count:count-words "Joe can't tell between 'large' and large.")))
+(test with-quotations
+  (is (assert-alist-equal
+       '(("joe" . 1) ("can't" . 1) ("tell" . 1) ("between" . 1) ("large" . 2)
+         ("and" . 1))
+       (word-count:count-words "Joe can't tell between 'large' and large."))))
 
 
-(define-test
-  substrings-from-the-beginning
-  (assert-alist-equal
-    '(("joe" . 1) ("can't" . 1) ("tell" . 1) ("between" . 1) ("app" . 1)
-      ("apple" . 1) ("and" . 1) ("a" . 1))
-    (word-count:count-words "Joe can't tell between app, apple and a.")))
+(test substrings-from-the-beginning
+  (is (assert-alist-equal
+       '(("joe" . 1) ("can't" . 1) ("tell" . 1) ("between" . 1) ("app" . 1)
+         ("apple" . 1) ("and" . 1) ("a" . 1))
+       (word-count:count-words "Joe can't tell between app, apple and a."))))
 
 
-(define-test
-  multiple-spaces-not-detected-as-a-word
-  (assert-alist-equal
-    '(("multiple" . 1) ("whitespaces" . 1))
-    (word-count:count-words " multiple   whitespaces")))
+(test multiple-spaces-not-detected-as-a-word
+  (is (assert-alist-equal
+       '(("multiple" . 1) ("whitespaces" . 1))
+       (word-count:count-words " multiple   whitespaces"))))
 
 
-(define-test
-  alternating-word-separators-not-detected-as-a-word
-  (assert-alist-equal
-    '(("one" . 1) ("two" . 1) ("three" . 1))
-    (word-count:count-words ",
+(test alternating-word-separators-not-detected-as-a-word
+  (is (assert-alist-equal
+       '(("one" . 1) ("two" . 1) ("three" . 1))
+       (word-count:count-words ",
 ,one,
  ,two
- 'three'")))
+ 'three'"))))
 
-#-xlisp-test
-(let ((*print-errors* t)
-      (*print-failures* t))
-  (run-tests :all))
+(defun run-tests (&optional (test-or-suite 'word-count-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/word-count/word-count.lisp
+++ b/exercises/practice/word-count/word-count.lisp
@@ -1,4 +1,3 @@
-(in-package #:cl-user)
 (defpackage #:word-count
   (:use #:cl)
   (:export #:count-words))

--- a/src/one-off-scripts/v2-to-v3.lisp
+++ b/src/one-off-scripts/v2-to-v3.lisp
@@ -1,0 +1,181 @@
+;;;;
+;;;; HOW TO USE:
+;;;;
+;;;; (load "./src/one-off-scripts/v2-to-v3.lisp")
+;;;; (convert "./exercises/practice/robot-simulator/")
+;;;;
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (ql:quickload "yason"))
+
+;;;
+;;; proto-abstraction for "exercise"
+;;;
+(defun exercise-init (pathname)
+  (merge-pathnames pathname))
+
+(defun exercise-slug (exercise)
+  (first (last (pathname-directory exercise))))
+
+(defun exercise-file-name (exercise relative-path)
+  (merge-pathnames relative-path exercise))
+
+(defun exercise-test-file (exercise)
+  (exercise-file-name exercise
+                      (make-pathname :name (format nil "~A-test"
+                                                   (exercise-slug exercise))
+                                     :type "lisp")))
+
+(defun exercise-source-file (exercise)
+  (exercise-file-name exercise
+                      (make-pathname :name (exercise-slug exercise)
+                                     :type "lisp")))
+
+(defun exercise-config-file (exercise)
+  (exercise-file-name exercise
+                      (make-pathname :directory '(:relative ".meta")
+                                     :name "config"
+                                     :type "json")))
+
+;;;
+;;; Transformation of test file
+(defun load-test-forms (exercise)
+  ;; load source file to define package and symbols, will delete below
+  (load (exercise-source-file exercise))
+  (uiop:read-file-forms (exercise-test-file exercise)))
+
+(defun transform-quickload (slug form)
+  (declare (ignore form))
+  `((:comment
+     ,(format nil
+              "Ensures that ~A.lisp and the testing library are always loaded"
+              slug))
+    (eval-when (:compile-toplevel :load-toplevel :execute)
+      (load ,slug)
+      (ql:quickload :fiveam))))
+
+(defun transform-defpackage (slug form)
+  (list (list :comment
+              (format nil "Defines the testing package with symbols from ~A and FiveAM in scope" slug))
+        (list :comment "The `run-tests` function is exported for use by both the user and test-runner")
+        (append (substitute-if '(:use #:cl #:fiveam)
+                        #'(lambda (x) (and (listp x) (eq (car x) :use)))
+                        form)
+                '((:export #:run-tests)))))
+
+(defun transform-inpackage (slug form)
+  (list (list :comment "Enter the testing package")
+        form
+        "" ;; blank line
+        (list :comment "Define and enter a new FiveAM test-suite")
+        (list 'def-suite* (intern (format nil "~:@(~A~)-SUITE" slug)))))
+
+(defun transform-define-test (slug form)
+  `(test ,(second form)
+         ,@(transform slug (cddr form))))
+
+(defun transform-let (slug form)
+  (append '(let)
+          (list (second form))
+          (transform slug (cddr form))))
+
+(defun transform-assert-equal (slug form)
+  (declare (ignore slug))
+  `(is (equal ,@(cdr form))))
+
+(defun run-test-block-p (form)
+  "Checks if LET expression is the old v2 'run-test' block by looking at first
+variable binding."
+  (member (caaadr form) '(*print-errors* *print-failures*)))
+
+(defun transform-run-test-block (slug form)
+  (declare (ignore form))
+  `(defun run-tests (&optional (test-or-suite
+                                ,`(quote ,(intern (format nil "~:@(~A~)-SUITE" slug)))))
+     "Provides human readable results of test run. Default to entire suite."
+     (run! test-or-suite)))
+
+;;; big messy old dispatcher.
+;;; especially messy because of some silly special casing.
+(defun transform (slug forms)
+  (do ((form (car forms) (car forms))
+       (forms (cdr forms) (cdr forms))
+       (result (list)))
+      ((null form) (nreverse result))
+
+    (cond ((atom form) (push form result))
+          ((eq (car form) 'quicklisp-client:quickload)
+           (push (transform-quickload slug form) result))
+          ((equal form (list 'load slug)) nil)
+          ((eq (car form) 'defpackage)
+           (push (transform-defpackage slug form) result))
+          ((eq (car form) 'in-package)
+           (push (transform-inpackage slug form) result))
+          ((eq (car form) 'define-test)
+           (push (transform-define-test slug form) result))
+          ((eq (car form) 'let)
+           (push (if (run-test-block-p form)
+                     (transform-run-test-block slug form)
+                     (transform-let slug form))
+                 result))
+          ((eq (car form) 'assert-equal)
+           (push (transform-assert-equal slug form) result))
+          (t (push (transform slug form) result)))))
+
+;;;
+;;; Writing
+;;;
+(defun write-form (expr stream)
+  "Write a EXPR to STREAM. EXPR is either FORM or ((:COMMENT STRING)+ FORM)"
+
+  (if (and (listp expr)
+           (listp (car expr))
+           (eq (caar expr) :comment))
+
+      (dolist (form expr)
+        (if (and (listp form) (eq (car form) :comment))
+            (write-form (format nil ";; ~A" (cadr form)) stream)
+            (write-form form stream)))
+
+      (format stream "~@?~%" (if (stringp expr) "~A" "~S") expr)))
+
+(defun write-forms (forms stream)
+  (let ((*print-case* :downcase))
+
+    (write-form (car forms) stream)
+    (dolist (form (cdr forms))
+      (terpri stream)
+      (write-form form stream))))
+
+
+;;;
+;;; Entire Converstion
+;;;
+(defun convert-exercise (path-to-exercise)
+  "Converts a v2 exercise to a v3 exercise.
+EXERCISE must be a pathname to the v2 exercise directory (relative is OK).
+Behavior undefined if run on a v3 exercise.
+Does not evaluate to any useful value."
+  (when (member :xlisp-test *features*)
+    (format *debug-io* ";; :XLISP-TEST found in *FEATURES* removing!!~&")
+    (setq *features* (delete :xlisp-test *features*)))
+
+  (let ((exercise (exercise-init path-to-exercise)))
+    ;; transform test file
+    (let ((forms (load-test-forms exercise))
+          (test-file (exercise-test-file exercise))
+          (slug (exercise-slug exercise)))
+      (format *debug-io* ";; CONVERT ~A~&" test-file)
+      (with-open-file (stream test-file
+                       :direction :output
+                       :if-exists :supersede)
+        (write-forms (transform slug forms) stream)))
+
+    ;; transform config profile
+    (let ((config-file (exercise-config-file exercise)))
+      (format *debug-io* ";; CONVERT ~A~&" config-file)
+      (let ((config (yason:parse config-file)))
+        (remhash "v2" config)
+        (with-open-file (stream config-file :direction :output :if-exists :supersede)
+          (yason:encode config (yason:make-json-output-stream stream))))))
+  (values))

--- a/src/one-off-scripts/v2-to-v3.lisp
+++ b/src/one-off-scripts/v2-to-v3.lisp
@@ -83,6 +83,22 @@
   (declare (ignore slug))
   `(is (equal ,@(cdr form))))
 
+(defun transform-assert-equalp (slug form)
+  (declare (ignore slug))
+  `(is (equalp ,@(cdr form))))
+
+(defun transform-assert-true (slug form)
+  (declare (ignore slug))
+  `(is ,@(cdr form)))
+
+(defun transform-assert-false (slug form)
+  (declare (ignore slug))
+  `(is (not ,@(cdr form))))
+
+(defun transform-assert-error (slug form)
+  (declare (ignore slug))
+  `(signals ,@(cdr form)))
+
 (defun run-test-block-p (form)
   "Checks if LET expression is the old v2 'run-test' block by looking at first
 variable binding."
@@ -120,6 +136,14 @@ variable binding."
                  result))
           ((eq (car form) 'assert-equal)
            (push (transform-assert-equal slug form) result))
+          ((eq (car form) 'assert-equalp)
+           (push (transform-assert-equalp slug form) result))
+          ((eq (car form) 'assert-true)
+           (push (transform-assert-true slug form) result))
+          ((eq (car form) 'assert-false)
+           (push (transform-assert-false slug form) result))
+          ((eq (car form) 'assert-error)
+           (push (transform-assert-error slug form) result))
           (t (push (transform slug form) result)))))
 
 ;;;

--- a/src/test-exercises/packages.lisp
+++ b/src/test-exercises/packages.lisp
@@ -1,3 +1,3 @@
 (defpackage #:test-exercises
   (:use :cl)
-  (:export #:run-all-tests))
+  (:export #:run-all-tests #:test-exercise))

--- a/src/test-exercises/run.lisp
+++ b/src/test-exercises/run.lisp
@@ -3,11 +3,14 @@
 ;; for v2 test running
 (pushnew :xlisp-test *features*)
 
+(defun example-files (data)
+  (or (aget :exemplar (aget :files data))
+      (aget :example (aget :files data))))
+
 (defun test-v2-exercise (data)
   (let ((test-files (aget :test (aget :files data)))
         (solution-files (aget :solution (aget :files data)))
-        (exemplar-files (or (aget :exemplar (aget :files data))
-                            (aget :example (aget :files data)))))
+        (exemplar-files (example-files data)))
     (unwind-protect
          (progn
            (dolist (f (append solution-files exemplar-files test-files))
@@ -20,8 +23,7 @@
 
 (defun test-v3-exercise (data)
   (let ((test-files (aget :test (aget :files data)))
-        (exemplar-files (aget :exemplar (aget :files data))))
-
+        (exemplar-files (example-files data)))
     (unwind-protect
          (progn
            (dolist (f (append test-files exemplar-files))


### PR DESCRIPTION
This PR holds changes needed to convert practice exercises. The first commits are those needed to set up the CI system and a on-off-script to do the conversion. The next commits are the application of the script to convert as many exercises as possible. 

Some were not convertable "automatically" however.

Exercises that did not "easily" convert are:

- [x] BEER-SONG
- [x] HELLO-WORLD
- [x] NUCLEOTIDE-COUNT
- [x] RNA-TRANSCRIPTION
- [x] ROBOT-NAME
- [x] ROMAN-NUMBERS
- [x] SPACE-AGE
- [x] TWELVE-DAYS
- [x] WORD-COUNT

The above where then converted with a combination of automatic & manual conversion.

The final commits address a couple of style issues I saw while working on this. Once we have a generator for exercises then this sort of style thing will not have to be addressed manually any more.