### PR TITLE
🤖 Add file patterns to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,6 +14,20 @@
     "indent_style": "space",
     "indent_size": 2
   },
+  "files": {
+    "solution": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "test": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "example": [
+      "path/to/%{kebab_slug}.ext"
+    ],
+    "exemplar": [
+      "path/to/%{kebab_slug}.ext"
+    ]
+  },
   "exercises": {
     "concept": [
       {

--- a/config.json
+++ b/config.json
@@ -15,18 +15,10 @@
     "indent_size": 2
   },
   "files": {
-    "solution": [
-      "path/to/%{kebab_slug}.ext"
-    ],
-    "test": [
-      "path/to/%{kebab_slug}.ext"
-    ],
-    "example": [
-      "path/to/%{kebab_slug}.ext"
-    ],
-    "exemplar": [
-      "path/to/%{kebab_slug}.ext"
-    ]
+    "solution": ["./%{kebab_slug}.lisp"],
+    "test": ["./%{kebab_slug}-test.lisp"],
+    "example": ["./.meta/example.lisp"],
+    "exemplar": ["./.meta/exempler.lisp"]
   },
   "exercises": {
     "concept": [
@@ -34,12 +26,7 @@
         "slug": "socks-and-sexprs",
         "name": "Sorting Socks and Sexprs",
         "uuid": "6787f07b-6fca-48ec-9ed1-f37bb77126f2",
-        "concepts": [
-          "comments",
-          "expressions",
-          "cons",
-          "symbols"
-        ],
+        "concepts": ["comments", "expressions", "cons", "symbols"],
         "prerequisites": [],
         "status": "beta"
       },
@@ -47,9 +34,7 @@
         "slug": "key-comparison",
         "name": "The Key to Comparison",
         "uuid": "d780fb3e-c9f8-11ea-af82-3200111e0c80",
-        "concepts": [
-          "sameness"
-        ],
+        "concepts": ["sameness"],
         "prerequisites": [
           "characters",
           "strings",
@@ -64,22 +49,14 @@
         "slug": "pizza-pi",
         "name": "Pizza Pi",
         "uuid": "f78cff23-2106-4e35-b439-2d8bd2830770",
-        "concepts": [
-          "integers",
-          "floating-point-numbers",
-          "arithmetic"
-        ],
-        "prerequisites": [
-          "expressions"
-        ],
+        "concepts": ["integers", "floating-point-numbers", "arithmetic"],
+        "prerequisites": ["expressions"],
         "status": "beta"
       },
       {
         "slug": "destructuring-assignment",
         "uuid": null,
-        "concepts": [
-          "destructuring-assignment"
-        ],
+        "concepts": ["destructuring-assignment"],
         "prerequisites": [
           "lists",
           "symbols",
@@ -92,9 +69,7 @@
       {
         "slug": "code-as-data",
         "uuid": null,
-        "concepts": [
-          "code-as-data"
-        ],
+        "concepts": ["code-as-data"],
         "prerequisites": [
           "lists",
           "arithmetic",
@@ -109,9 +84,7 @@
       {
         "slug": "multiple-values",
         "uuid": null,
-        "concepts": [
-          "multiple-values"
-        ],
+        "concepts": ["multiple-values"],
         "prerequisites": [
           "lists",
           "arithmetic",
@@ -124,9 +97,7 @@
       {
         "slug": "hash-tables",
         "uuid": null,
-        "concepts": [
-          "hash-tables"
-        ],
+        "concepts": ["hash-tables"],
         "prerequisites": [
           "assignment",
           "multiple-values",
@@ -140,35 +111,21 @@
       {
         "slug": "structures",
         "uuid": null,
-        "concepts": [
-          "structures"
-        ],
-        "prerequisites": [
-          "assignment",
-          "functions",
-          "variables",
-          "symbols"
-        ],
+        "concepts": ["structures"],
+        "prerequisites": ["assignment", "functions", "variables", "symbols"],
         "status": "beta"
       },
       {
         "slug": "characters",
         "uuid": null,
-        "concepts": [
-          "characters"
-        ],
-        "prerequisites": [
-          "integers",
-          "truthy-and-falsy"
-        ],
+        "concepts": ["characters"],
+        "prerequisites": ["integers", "truthy-and-falsy"],
         "status": "beta"
       },
       {
         "slug": "sets",
         "uuid": null,
-        "concepts": [
-          "sets"
-        ],
+        "concepts": ["sets"],
         "prerequisites": [
           "lists",
           "higher-order-functions",
@@ -181,23 +138,14 @@
       {
         "slug": "assignment",
         "uuid": null,
-        "concepts": [
-          "assignment"
-        ],
-        "prerequisites": [
-          "variables",
-          "lists",
-          "strings",
-          "expressions"
-        ],
+        "concepts": ["assignment"],
+        "prerequisites": ["variables", "lists", "strings", "expressions"],
         "status": "beta"
       },
       {
         "slug": "nested-functions",
         "uuid": null,
-        "concepts": [
-          "nested-functions"
-        ],
+        "concepts": ["nested-functions"],
         "prerequisites": [
           "variables",
           "functions",
@@ -209,9 +157,7 @@
       {
         "slug": "recursion",
         "uuid": null,
-        "concepts": [
-          "recursion"
-        ],
+        "concepts": ["recursion"],
         "prerequisites": [
           "nested-functions",
           "functions",
@@ -226,9 +172,7 @@
       {
         "slug": "anonymous-functions",
         "uuid": null,
-        "concepts": [
-          "anonymous-functions"
-        ],
+        "concepts": ["anonymous-functions"],
         "prerequisites": [
           "functions",
           "higher-order-functions",
@@ -240,9 +184,7 @@
       {
         "slug": "higher-order-functions",
         "uuid": null,
-        "concepts": [
-          "higher-order-functions"
-        ],
+        "concepts": ["higher-order-functions"],
         "prerequisites": [
           "lists",
           "strings",
@@ -256,62 +198,35 @@
         "slug": "leslies-lists",
         "name": "Leslie's Lengthy Lists",
         "uuid": "fd1aaa1a-f3c0-419e-a713-761c5147a5e1",
-        "concepts": [
-          "lists"
-        ],
-        "prerequisites": [
-          "cons",
-          "symbols",
-          "arithmetic"
-        ],
+        "concepts": ["lists"],
+        "prerequisites": ["cons", "symbols", "arithmetic"],
         "status": "beta"
       },
       {
         "slug": "packages",
         "uuid": null,
-        "concepts": [
-          "packages"
-        ],
-        "prerequisites": [
-          "variables",
-          "symbols",
-          "functions"
-        ],
+        "concepts": ["packages"],
+        "prerequisites": ["variables", "symbols", "functions"],
         "status": "beta"
       },
       {
         "slug": "enumeration",
         "uuid": null,
-        "concepts": [
-          "enumeration",
-          "loop.basic"
-        ],
-        "prerequisites": [
-          "arithmetic",
-          "strings",
-          "lists"
-        ],
+        "concepts": ["enumeration", "loop.basic"],
+        "prerequisites": ["arithmetic", "strings", "lists"],
         "status": "beta"
       },
       {
         "slug": "strings",
         "uuid": null,
-        "concepts": [
-          "strings",
-          "printing"
-        ],
-        "prerequisites": [
-          "expressions"
-        ],
+        "concepts": ["strings", "printing"],
+        "prerequisites": ["expressions"],
         "status": "beta"
       },
       {
         "slug": "variables",
         "uuid": null,
-        "concepts": [
-          "constants",
-          "variables"
-        ],
+        "concepts": ["constants", "variables"],
         "prerequisites": [
           "arithmetic",
           "expressions",
@@ -325,10 +240,7 @@
         "slug": "pal-picker",
         "name": "Pal Picker",
         "uuid": "c0155014-4d11-4cb2-872b-6dfdf794f7cd",
-        "concepts": [
-          "conditionals",
-          "truthy-and-falsy"
-        ],
+        "concepts": ["conditionals", "truthy-and-falsy"],
         "prerequisites": [
           "expressions",
           "integers",
@@ -342,14 +254,8 @@
         "slug": "lillys-lasagna",
         "name": "Lilly's Lasagna",
         "uuid": "825df850-2f38-11eb-a817-542696d187f9",
-        "concepts": [
-          "functions"
-        ],
-        "prerequisites": [
-          "expressions",
-          "integers",
-          "arithmetic"
-        ],
+        "concepts": ["functions"],
+        "prerequisites": ["expressions", "integers", "arithmetic"],
         "status": "beta"
       },
       {
@@ -362,11 +268,7 @@
           "default-parameters",
           "rest-parameters"
         ],
-        "prerequisites": [
-          "functions",
-          "symbols",
-          "conditionals"
-        ],
+        "prerequisites": ["functions", "symbols", "conditionals"],
         "status": "beta"
       }
     ],
@@ -378,9 +280,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "strings"
-        ],
+        "topics": ["strings"],
         "status": "wip"
       },
       {
@@ -390,11 +290,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "optional_values",
-          "strings",
-          "text_formatting"
-        ],
+        "topics": ["optional_values", "strings", "text_formatting"],
         "status": "wip"
       },
       {
@@ -404,13 +300,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "equality",
-          "filtering",
-          "loops",
-          "strings"
-        ],
+        "topics": ["conditionals", "equality", "filtering", "loops", "strings"],
         "status": "wip"
       },
       {
@@ -420,11 +310,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "strings",
-          "transforming"
-        ],
+        "topics": ["conditionals", "strings", "transforming"],
         "status": "wip"
       },
       {
@@ -434,12 +320,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "equality",
-          "integers",
-          "logic"
-        ],
+        "topics": ["conditionals", "equality", "integers", "logic"],
         "status": "wip"
       },
       {
@@ -449,11 +330,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "equality",
-          "filtering",
-          "strings"
-        ],
+        "topics": ["equality", "filtering", "strings"],
         "status": "wip"
       },
       {
@@ -463,12 +340,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "integers",
-          "loops",
-          "text_formatting"
-        ],
+        "topics": ["conditionals", "integers", "loops", "text_formatting"],
         "status": "wip"
       },
       {
@@ -494,12 +366,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "filtering",
-          "loops",
-          "strings"
-        ],
+        "topics": ["conditionals", "filtering", "loops", "strings"],
         "status": "wip"
       },
       {
@@ -509,11 +376,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "parsing",
-          "strings"
-        ],
+        "topics": ["conditionals", "parsing", "strings"],
         "status": "wip"
       },
       {
@@ -523,10 +386,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "algorithms",
-          "strings"
-        ],
+        "topics": ["algorithms", "strings"],
         "status": "wip"
       },
       {
@@ -536,10 +396,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "strings",
-          "transforming"
-        ],
+        "topics": ["strings", "transforming"],
         "status": "wip"
       },
       {
@@ -549,11 +406,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "integers",
-          "math",
-          "transforming"
-        ],
+        "topics": ["integers", "math", "transforming"],
         "status": "wip"
       },
       {
@@ -578,11 +431,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "integers",
-          "lists",
-          "math"
-        ],
+        "topics": ["integers", "lists", "math"],
         "status": "wip"
       },
       {
@@ -592,12 +441,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "bitwise_operations",
-          "conditionals",
-          "integers",
-          "math"
-        ],
+        "topics": ["bitwise_operations", "conditionals", "integers", "math"],
         "status": "wip"
       },
       {
@@ -607,11 +451,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "loops",
-          "sequences",
-          "strings"
-        ],
+        "topics": ["loops", "sequences", "strings"],
         "status": "wip"
       },
       {
@@ -621,11 +461,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "integers",
-          "math",
-          "recursion"
-        ],
+        "topics": ["integers", "math", "recursion"],
         "status": "wip"
       },
       {
@@ -635,12 +471,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "floating_point_numbers",
-          "integers",
-          "loops",
-          "math"
-        ],
+        "topics": ["floating_point_numbers", "integers", "loops", "math"],
         "status": "wip"
       },
       {
@@ -650,11 +481,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "loops",
-          "maps",
-          "transforming"
-        ],
+        "topics": ["loops", "maps", "transforming"],
         "status": "wip"
       },
       {
@@ -664,13 +491,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "dates",
-          "integers",
-          "time",
-          "transforming",
-          "variables"
-        ],
+        "topics": ["dates", "integers", "time", "transforming", "variables"],
         "status": "wip"
       },
       {
@@ -680,10 +501,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "integers",
-          "variables"
-        ],
+        "topics": ["integers", "variables"],
         "status": "wip"
       },
       {
@@ -693,9 +511,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "strings"
-        ],
+        "topics": ["strings"],
         "status": "wip"
       },
       {
@@ -705,12 +521,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "loops",
-          "maps",
-          "sorting",
-          "strings"
-        ],
+        "topics": ["loops", "maps", "sorting", "strings"],
         "status": "wip"
       },
       {
@@ -720,12 +531,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "integers",
-          "loops",
-          "math",
-          "sequences"
-        ],
+        "topics": ["integers", "loops", "math", "sequences"],
         "status": "wip"
       },
       {
@@ -735,9 +541,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "math"
-        ],
+        "topics": ["math"],
         "status": "wip"
       },
       {
@@ -747,11 +551,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "filtering",
-          "integers"
-        ],
+        "topics": ["conditionals", "filtering", "integers"],
         "status": "wip"
       },
       {
@@ -761,12 +561,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "games",
-          "loops",
-          "maps",
-          "strings"
-        ],
+        "topics": ["games", "loops", "maps", "strings"],
         "status": "wip"
       },
       {
@@ -793,11 +588,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "floating_point_numbers",
-          "interfaces",
-          "transforming"
-        ],
+        "topics": ["floating_point_numbers", "interfaces", "transforming"],
         "status": "wip"
       },
       {
@@ -807,12 +598,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "filtering",
-          "loops",
-          "sequences"
-        ],
+        "topics": ["conditionals", "filtering", "loops", "sequences"],
         "status": "wip"
       },
       {
@@ -822,9 +608,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "lists"
-        ],
+        "topics": ["lists"],
         "status": "wip"
       },
       {
@@ -849,11 +633,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "integers",
-          "math"
-        ],
+        "topics": ["conditionals", "integers", "math"],
         "status": "wip"
       },
       {
@@ -863,12 +643,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "loops",
-          "sequences",
-          "transforming"
-        ],
+        "topics": ["conditionals", "loops", "sequences", "transforming"],
         "status": "wip"
       },
       {
@@ -878,13 +653,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "interfaces",
-          "lists",
-          "maps",
-          "sorting",
-          "variables"
-        ],
+        "topics": ["interfaces", "lists", "maps", "sorting", "variables"],
         "status": "wip"
       },
       {
@@ -894,11 +663,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "interfaces",
-          "parsing",
-          "strings"
-        ],
+        "topics": ["interfaces", "parsing", "strings"],
         "status": "wip"
       },
       {
@@ -925,11 +690,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "randomness",
-          "strings",
-          "variables"
-        ],
+        "topics": ["randomness", "strings", "variables"],
         "status": "wip"
       },
       {
@@ -939,11 +700,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "loops",
-          "sequences",
-          "strings"
-        ],
+        "topics": ["loops", "sequences", "strings"],
         "status": "wip"
       },
       {
@@ -969,11 +726,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "conditionals",
-          "dates",
-          "filtering"
-        ],
+        "topics": ["conditionals", "dates", "filtering"],
         "status": "wip"
       },
       {
@@ -983,18 +736,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "strings",
-          "transforming"
-        ],
+        "topics": ["algorithms", "strings", "transforming"],
         "status": "wip"
       }
     ],
-    "foregone": [
-      "accumulate",
-      "bank-account"
-    ]
+    "foregone": ["accumulate", "bank-account"]
   },
   "concepts": [
     {


### PR DESCRIPTION
**⚠ This PR requires you to make a simple change before merging. ⚠**

---

To save maintainers from having to manually specify the `files` key in their exercises' `.meta/config.json` files, we are providing support for track-level patterns. See [this PR](https://github.com/exercism/docs/pull/58) for details.

This PR adds (**purposefully wrong**) file patterns to the `config.json` file. It is up to you, the track maintainers, to change these patterns to their correct value.

You can use the following placeholders:
- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)

We will soon update `configlet` to enable it to automatically populate the `.meta/config.json` file's `files` property, at which point we will then batch-PR updates to all tracks that have merged this PR.

## Tracking
https://github.com/exercism/v3-launch/issues/19
