### PR TITLE
Update instructions to not allow 0 area triangle

### DIFF
--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -13,8 +13,8 @@ A _scalene_ triangle has all sides of different lengths.
 ## Note
 
 For a shape to be a triangle at all, all sides have to be of length > 0, and
-the sum of the lengths of any two sides must be greater than or equal to the
-length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+the sum of the lengths of any two sides must be greater than the length of the
+third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
 
 ## Dig Deeper
 


### PR DESCRIPTION
The test cases for this exercise contain a test case to disallow 0 area triangles

```
(test invalid-2 (is (equal :illogical (triangle:triangle 1 2 1))))
```

It is arguable what is correct, a triangle with `a + b = c` has an area of 0, but is correct in terms of the triangle equation. I choose to update the instructions to only allow `a + b > c`.