### PR TITLE
🤖 Add blurb to .meta/config.json files

### DIFF
--- a/exercises/concept/key-comparison/.meta/config.json
+++ b/exercises/concept/key-comparison/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for key-comparison exercise",
   "authors": [
     {
       "github_username": "verdammelt",
@@ -10,8 +11,14 @@
     }
   ],
   "files": {
-    "solution": ["key-comparison.lisp"],
-    "test": ["key-comparison-test.lisp"],
-    "exemplar": [".meta/exemplar.lisp"]
+    "solution": [
+      "key-comparison.lisp"
+    ],
+    "test": [
+      "key-comparison-test.lisp"
+    ],
+    "exemplar": [
+      ".meta/exemplar.lisp"
+    ]
   }
 }

--- a/exercises/concept/leslies-lists/.meta/config.json
+++ b/exercises/concept/leslies-lists/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for leslies-lists exercise",
   "authors": [
     {
       "github_username": "verdammelt",
@@ -6,8 +7,14 @@
     }
   ],
   "files": {
-    "solution": ["leslies-lists.lisp"],
-    "test": ["leslies-lists-test.lisp"],
-    "exemplar": [".meta/exemplar.lisp"]
+    "solution": [
+      "leslies-lists.lisp"
+    ],
+    "test": [
+      "leslies-lists-test.lisp"
+    ],
+    "exemplar": [
+      ".meta/exemplar.lisp"
+    ]
   }
 }

--- a/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
+++ b/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for lillys-lasagna-leftovers exercise",
   "authors": [
     {
       "github_username": "verdammelt",
@@ -6,10 +7,18 @@
     }
   ],
   "contributors": [],
-  "forked_from": ["swift/lasagna-master"],
+  "forked_from": [
+    "swift/lasagna-master"
+  ],
   "files": {
-    "solution": ["lillys-lasagna-leftovers.lisp"],
-    "test": ["lillys-lasagna-leftovers-test.lisp"],
-    "exemplar": [".meta/exemplar.lisp"]
+    "solution": [
+      "lillys-lasagna-leftovers.lisp"
+    ],
+    "test": [
+      "lillys-lasagna-leftovers-test.lisp"
+    ],
+    "exemplar": [
+      ".meta/exemplar.lisp"
+    ]
   }
 }

--- a/exercises/concept/lillys-lasagna/.meta/config.json
+++ b/exercises/concept/lillys-lasagna/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for lillys-lasagna exercise",
   "authors": [
     {
       "github_username": "verdammelt",
@@ -6,10 +7,18 @@
     }
   ],
   "contributors": [],
-  "forked_from": ["ruby/lasagna"],
+  "forked_from": [
+    "ruby/lasagna"
+  ],
   "files": {
-    "solution": ["lillys-lasagna.lisp"],
-    "test": ["lillys-lasagna-test.lisp"],
-    "exemplar": [".meta/exemplar.lisp"]
+    "solution": [
+      "lillys-lasagna.lisp"
+    ],
+    "test": [
+      "lillys-lasagna-test.lisp"
+    ],
+    "exemplar": [
+      ".meta/exemplar.lisp"
+    ]
   }
 }

--- a/exercises/concept/pal-picker/.meta/config.json
+++ b/exercises/concept/pal-picker/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for pal-picker exercise",
   "authors": [
     {
       "github_username": "TheLostLambda",
@@ -6,8 +7,14 @@
     }
   ],
   "files": {
-    "solution": ["pal-picker.lisp"],
-    "test": ["pal-picker-test.lisp"],
-    "exemplar": [".meta/exemplar.lisp"]
+    "solution": [
+      "pal-picker.lisp"
+    ],
+    "test": [
+      "pal-picker-test.lisp"
+    ],
+    "exemplar": [
+      ".meta/exemplar.lisp"
+    ]
   }
 }

--- a/exercises/concept/pizza-pi/.meta/config.json
+++ b/exercises/concept/pizza-pi/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for pizza-pi exercise",
   "authors": [
     {
       "github_username": "TheLostLambda",
@@ -10,8 +11,14 @@
     }
   ],
   "files": {
-    "solution": ["pizza-pi.lisp"],
-    "test": ["pizza-pi-test.lisp"],
-    "exemplar": [".meta/exemplar.lisp"]
+    "solution": [
+      "pizza-pi.lisp"
+    ],
+    "test": [
+      "pizza-pi-test.lisp"
+    ],
+    "exemplar": [
+      ".meta/exemplar.lisp"
+    ]
   }
 }

--- a/exercises/concept/socks-and-sexprs/.meta/config.json
+++ b/exercises/concept/socks-and-sexprs/.meta/config.json
@@ -1,4 +1,5 @@
 {
+  "blurb": "TODO: add blurb for socks-and-sexprs exercise",
   "authors": [
     {
       "github_username": "verdammelt",
@@ -10,8 +11,14 @@
     }
   ],
   "files": {
-    "solution": ["socks-and-sexprs.lisp"],
-    "test": ["socks-and-sexprs-test.lisp"],
-    "exemplar": [".meta/exemplar.lisp"]
+    "solution": [
+      "socks-and-sexprs.lisp"
+    ],
+    "test": [
+      "socks-and-sexprs-test.lisp"
+    ],
+    "exemplar": [
+      ".meta/exemplar.lisp"
+    ]
   }
 }

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://github.com/monkbroc",
-  "source":"Julien Vanier",
-  "files":{
-    "test":[
+  "blurb": "Convert a long phrase to its acronym",
+  "source_url": "https://github.com/monkbroc",
+  "source": "Julien Vanier",
+  "files": {
+    "test": [
       "acronym-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "acronym.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,14 +1,15 @@
 {
-  "files":{
-    "test":[
+  "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
+  "files": {
+    "test": [
       "all-your-base-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "all-your-base.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://jumpstartlab.com",
-  "source":"Jumpstart Lab Warm-up",
-  "files":{
-    "test":[
+  "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
+  "source_url": "http://jumpstartlab.com",
+  "source": "Jumpstart Lab Warm-up",
+  "files": {
+    "test": [
       "allergies-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "allergies.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://github.com/rchatley/extreme_startup",
-  "source":"Inspired by the Extreme Startup game",
-  "files":{
-    "test":[
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
+  "source_url": "https://github.com/rchatley/extreme_startup",
+  "source": "Inspired by the Extreme Startup game",
+  "files": {
+    "test": [
       "anagram-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "anagram.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://en.wikipedia.org/wiki/Narcissistic_number",
-  "source":"Wikipedia",
-  "files":{
-    "test":[
+  "blurb": "Determine if a number is an Armstrong number",
+  "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number",
+  "source": "Wikipedia",
+  "files": {
+    "test": [
       "armstrong-numbers-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "armstrong-numbers.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://en.wikipedia.org/wiki/Atbash",
-  "source":"Wikipedia",
-  "files":{
-    "test":[
+  "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
+  "source_url": "http://en.wikipedia.org/wiki/Atbash",
+  "source": "Wikipedia",
+  "files": {
+    "test": [
       "atbash-cipher-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "atbash-cipher.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://pine.fm/LearnToProgram/?Chapter=06",
-  "source":"Learn to Program by Chris Pine",
-  "files":{
-    "test":[
+  "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
+  "source": "Learn to Program by Chris Pine",
+  "files": {
+    "test": [
       "beer-song-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "beer-song.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://en.wikipedia.org/wiki/Binary_search_algorithm",
-  "source":"Wikipedia",
-  "files":{
-    "test":[
+  "blurb": "Implement a binary search algorithm.",
+  "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm",
+  "source": "Wikipedia",
+  "files": {
+    "test": [
       "binary-search-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "binary-search.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
-  "source":"All of Computer Science",
-  "files":{
-    "test":[
+  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
+  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
+  "source": "All of Computer Science",
+  "files": {
+    "test": [
       "binary-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "binary.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://pine.fm/LearnToProgram/?Chapter=06",
-  "source":"Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
-  "files":{
-    "test":[
+  "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
+  "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
+  "files": {
+    "test": [
       "bob-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "bob.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://en.wikipedia.org/wiki/3x_%2B_1_problem",
-  "source":"An unsolved problem in mathematics named after mathematician Lothar Collatz",
-  "files":{
-    "test":[
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
+  "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem",
+  "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
+  "files": {
+    "test": [
       "collatz-conjecture-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "collatz-conjecture.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
-  "source":"J Dalbey's Programming Practice problems",
-  "files":{
-    "test":[
+  "blurb": "Implement the classic method for composing secret messages called a square code.",
+  "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
+  "source": "J Dalbey's Programming Practice problems",
+  "files": {
+    "test": [
       "crypto-square-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "crypto-square.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://projecteuler.net/problem=6",
-  "source":"Problem 6 at Project Euler",
-  "files":{
-    "test":[
+  "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
+  "source_url": "http://projecteuler.net/problem=6",
+  "source": "Problem 6 at Project Euler",
+  "files": {
+    "test": [
       "difference-of-squares-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "difference-of-squares.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://jumpstartlab.com",
-  "source":"The Jumpstart Lab team",
-  "files":{
-    "test":[
+  "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
+  "source_url": "http://jumpstartlab.com",
+  "source": "The Jumpstart Lab team",
+  "files": {
+    "test": [
       "etl-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "etl.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://pine.fm/LearnToProgram/?Chapter=09",
-  "source":"Chapter 9 in Chris Pine's online Learn to Program tutorial.",
-  "files":{
-    "test":[
+  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
+  "source_url": "http://pine.fm/LearnToProgram/?Chapter=09",
+  "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
+  "files": {
+    "test": [
       "gigasecond-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "gigasecond.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://gschool.it",
-  "source":"A pairing session with Phil Battos at gSchool",
-  "files":{
-    "test":[
+  "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
+  "source_url": "http://gschool.it",
+  "source": "A pairing session with Phil Battos at gSchool",
+  "files": {
+    "test": [
       "grade-school-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "grade-school.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://www.javaranch.com/grains.jsp",
-  "source":"JavaRanch Cattle Drive, exercise 6",
-  "files":{
-    "test":[
+  "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
+  "source_url": "http://www.javaranch.com/grains.jsp",
+  "source": "JavaRanch Cattle Drive, exercise 6",
+  "files": {
+    "test": [
       "grains-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "grains.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://rosalind.info/problems/hamm/",
-  "source":"The Calculating Point Mutations problem at Rosalind",
-  "files":{
-    "test":[
+  "blurb": "Calculate the Hamming difference between two DNA strands.",
+  "source_url": "http://rosalind.info/problems/hamm/",
+  "source": "The Calculating Point Mutations problem at Rosalind",
+  "files": {
+    "test": [
       "hamming-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "hamming.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
-  "source":"This is an exercise to introduce users to using Exercism",
-  "files":{
-    "test":[
+  "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
+  "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
+  "source": "This is an exercise to introduce users to using Exercism",
+  "files": {
+    "test": [
       "hello-world-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "hello-world.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://en.wikipedia.org/wiki/Isogram",
-  "source":"Wikipedia",
-  "files":{
-    "test":[
+  "blurb": "Determine if a word or phrase is an isogram.",
+  "source_url": "https://en.wikipedia.org/wiki/Isogram",
+  "source": "Wikipedia",
+  "files": {
+    "test": [
       "isogram-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "isogram.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://www.javaranch.com/leap.jsp",
-  "source":"JavaRanch Cattle Drive, exercise 3",
-  "files":{
-    "test":[
+  "blurb": "Given a year, report if it is a leap year.",
+  "source_url": "http://www.javaranch.com/leap.jsp",
+  "source": "JavaRanch Cattle Drive, exercise 3",
+  "files": {
+    "test": [
       "leap-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "leap.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://en.wikipedia.org/wiki/Luhn_algorithm",
-  "source":"The Luhn Algorithm on Wikipedia",
-  "files":{
-    "test":[
+  "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
+  "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm",
+  "source": "The Luhn Algorithm on Wikipedia",
+  "files": {
+    "test": [
       "luhn-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "luhn.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://twitter.com/copiousfreetime",
-  "source":"Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
-  "files":{
-    "test":[
+  "blurb": "Calculate the date of meetups.",
+  "source_url": "https://twitter.com/copiousfreetime",
+  "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
+  "files": {
+    "test": [
       "meetup-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "meetup.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://rosalind.info/problems/dna/",
-  "source":"The Calculating DNA Nucleotides_problem at Rosalind",
-  "files":{
-    "test":[
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
+  "source_url": "http://rosalind.info/problems/dna/",
+  "source": "The Calculating DNA Nucleotides_problem at Rosalind",
+  "files": {
+    "test": [
       "nucleotide-count-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "nucleotide-count.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://mathworld.wolfram.com/PascalsTriangle.html",
-  "source":"Pascal's Triangle at Wolfram Math World",
-  "files":{
-    "test":[
+  "blurb": "Compute Pascal's triangle up to a given number of rows.",
+  "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html",
+  "source": "Pascal's Triangle at Wolfram Math World",
+  "files": {
+    "test": [
       "pascals-triangle-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "pascals-triangle.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://shop.oreilly.com/product/0636920029687.do",
-  "source":"Taken from Chapter 2 of Functional Thinking by Neal Ford.",
-  "files":{
-    "test":[
+  "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
+  "source_url": "http://shop.oreilly.com/product/0636920029687.do",
+  "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
+  "files": {
+    "test": [
       "perfect-numbers-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "perfect-numbers.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://tutorials.jumpstartlab.com/projects/eventmanager.html",
-  "source":"Event Manager by JumpstartLab",
-  "files":{
-    "test":[
+  "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
+  "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html",
+  "source": "Event Manager by JumpstartLab",
+  "files": {
+    "test": [
       "phone-number-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "phone-number.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata",
-  "source":"The Prime Factors Kata by Uncle Bob",
-  "files":{
-    "test":[
+  "blurb": "Compute the prime factors of a given natural number.",
+  "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata",
+  "source": "The Prime Factors Kata by Uncle Bob",
+  "files": {
+    "test": [
       "prime-factors-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "prime-factors.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://en.wikipedia.org/wiki/Fizz_buzz",
-  "source":"A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
-  "files":{
-    "test":[
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
+  "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz",
+  "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
+  "files": {
+    "test": [
       "raindrops-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "raindrops.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
-  "source":"Hyperphysics",
-  "files":{
-    "test":[
+  "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
+  "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
+  "source": "Hyperphysics",
+  "files": {
+    "test": [
       "rna-transcription-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "rna-transcription.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,15 +1,16 @@
 {
-  "source":"A debugging session with Paul Blackwell at gSchool.",
-  "files":{
-    "test":[
+  "blurb": "Manage robot factory settings.",
+  "source": "A debugging session with Paul Blackwell at gSchool.",
+  "files": {
+    "test": [
       "robot-name-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "robot-name.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"",
-  "source":"Inspired by an interview question at a famous company.",
-  "files":{
-    "test":[
+  "blurb": "Write a robot simulator.",
+  "source_url": "",
+  "source": "Inspired by an interview question at a famous company.",
+  "files": {
+    "test": [
       "robot-simulator-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "robot-simulator.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,10 +1,17 @@
 {
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals",
   "source": "The Roman Numeral Kata",
   "files": {
-    "test": ["roman-numerals-test.lisp"],
-    "solution": ["roman-numerals.lisp"],
-    "example": [".meta/example.lisp"]
+    "test": [
+      "roman-numerals-test.lisp"
+    ],
+    "solution": [
+      "roman-numerals.lisp"
+    ],
+    "example": [
+      ".meta/example.lisp"
+    ]
   },
   "authors": []
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://github.com/rchatley/extreme_startup",
-  "source":"Inspired by the Extreme Startup game",
-  "files":{
-    "test":[
+  "blurb": "Given a word, compute the Scrabble score for that word.",
+  "source_url": "https://github.com/rchatley/extreme_startup",
+  "source": "Inspired by the Extreme Startup game",
+  "files": {
+    "test": [
       "scrabble-score-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "scrabble-score.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes",
-  "source":"Sieve of Eratosthenes at Wikipedia",
-  "files":{
-    "test":[
+  "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
+  "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes",
+  "source": "Sieve of Eratosthenes at Wikipedia",
+  "files": {
+    "test": [
       "sieve-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "sieve.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,10 +1,17 @@
 {
+  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "files": {
-    "test": ["space-age-test.lisp"],
-    "solution": ["space-age.lisp"],
-    "example": [".meta/example.lisp"]
+    "test": [
+      "space-age-test.lisp"
+    ],
+    "solution": [
+      "space-age.lisp"
+    ],
+    "example": [
+      ".meta/example.lisp"
+    ]
   },
   "authors": []
 }

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"https://twitter.com/jeg2",
-  "source":"Conversation with James Edward Gray II",
-  "files":{
-    "test":[
+  "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
+  "source_url": "https://twitter.com/jeg2",
+  "source": "Conversation with James Edward Gray II",
+  "files": {
+    "test": [
       "strain-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "strain.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,14 +1,15 @@
 {
-  "files":{
-    "test":[
+  "blurb": "Write a function to determine if a list is a sublist of another list.",
+  "files": {
+    "test": [
       "sublist-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "sublist.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://rubykoans.com",
-  "source":"The Ruby Koans triangle project, parts 1 & 2",
-  "files":{
-    "test":[
+  "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
+  "source_url": "http://rubykoans.com",
+  "source": "The Ruby Koans triangle project, parts 1 & 2",
+  "files": {
+    "test": [
       "triangle-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "triangle.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
-  "source":"All of Computer Science",
-  "files":{
-    "test":[
+  "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
+  "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
+  "source": "All of Computer Science",
+  "files": {
+    "test": [
       "trinary-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "trinary.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,16 +1,17 @@
 {
-  "source_url":"http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)",
-  "source":"Wikipedia",
-  "files":{
-    "test":[
+  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
+  "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)",
+  "source": "Wikipedia",
+  "files": {
+    "test": [
       "twelve-days-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "twelve-days.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,15 +1,16 @@
 {
-  "source_url":"https://github.com/exercism/problem-specifications/issues/757",
-  "files":{
-    "test":[
+  "blurb": "Create a sentence of the form \"One for X, one for me.\"",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/757",
+  "files": {
+    "test": [
       "two-fer-test.lisp"
     ],
-    "solution":[
+    "solution": [
       "two-fer.lisp"
     ],
-    "example":[
+    "example": [
       ".meta/example.lisp"
     ]
   },
-  "authors":null
+  "authors": null
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,9 +1,16 @@
 {
+  "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.",
   "files": {
-    "test": ["word-count-test.lisp"],
-    "solution": ["word-count.lisp"],
-    "example": [".meta/example.lisp"]
+    "test": [
+      "word-count-test.lisp"
+    ],
+    "solution": [
+      "word-count.lisp"
+    ],
+    "example": [
+      ".meta/example.lisp"
+    ]
   },
   "authors": []
 }


### PR DESCRIPTION
Each Concept and Practice Exercise will have to define a _blurb_, which is a short description of the exercise.
The blurb will be displayed on a track's exercises page and on exercise tooltips. For example:

<img width="1194" alt="Screenshot 2021-03-02 at 13 25 38" src="https://user-images.githubusercontent.com/286476/109655154-da058500-7b5a-11eb-8346-bf733a72b3d0.png">
<img width="400" alt="Screenshot 2021-03-02 at 13 25 51" src="https://user-images.githubusercontent.com/286476/109655162-dd007580-7b5a-11eb-88f8-582532be9b84.png">

Blurbs must be limited to 350 chars and will be truncated in some views.

For Practice Exercises that are based on an exercise defined in the problem-specification repo, the blurb must match the contents of the problem-specifications exercises, which is defined in its `metadata.yml` file. In this PR, we'll do an initial syncing of the blurb. The new [configlet](https://github.com/exercism/configlet) version will add support for doing this syncing automatically.

If the Practice Exercise was _not_ based on a problems-specifications exercise, we've used the blurb from its `.meta/metadata.yml` file as the blurb in the .meta/config.json file.

For Concept Exercises, we've added a placeholder blurb to the .meta/config.json file of each Concept Exercise.

**We've opened an [issue for replacing the Concept Exercise placeholder blurbs](369) with sensible descriptions. Our recommendation is to merge this PR and then replace the placeholder blurbs in a follow-up PR. For forked exercises, it might be useful to check how other tracks have defined their blurb.**  

See the [Concept Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/concept-exercises.md#file-metaconfigjson) and [Practice Exercise spec](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson) for more information.

## Tracking

https://github.com/exercism/v3-launch/issues/21
