### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/key-comparison/.meta/config.json
+++ b/exercises/concept/key-comparison/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for key-comparison exercise",
   "authors": [
-    {
-      "github_username": "verdammelt",
-      "exercism_username": "verdammelt"
-    },
-    {
-      "github_username": "TheLostLambda",
-      "exercism_username": "TheLostLambda"
-    }
+    "verdammelt",
+    "TheLostLambda"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/leslies-lists/.meta/config.json
+++ b/exercises/concept/leslies-lists/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for leslies-lists exercise",
   "authors": [
-    {
-      "github_username": "verdammelt",
-      "exercism_username": "verdammelt"
-    }
+    "verdammelt"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
+++ b/exercises/concept/lillys-lasagna-leftovers/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for lillys-lasagna-leftovers exercise",
   "authors": [
-    {
-      "github_username": "verdammelt",
-      "exercism_username": "verdammelt"
-    }
+    "verdammelt"
   ],
   "contributors": [],
   "forked_from": [

--- a/exercises/concept/lillys-lasagna/.meta/config.json
+++ b/exercises/concept/lillys-lasagna/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for lillys-lasagna exercise",
   "authors": [
-    {
-      "github_username": "verdammelt",
-      "exercism_username": "verdammelt"
-    }
+    "verdammelt"
   ],
   "contributors": [],
   "forked_from": [

--- a/exercises/concept/pal-picker/.meta/config.json
+++ b/exercises/concept/pal-picker/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for pal-picker exercise",
   "authors": [
-    {
-      "github_username": "TheLostLambda",
-      "exercism_username": "TheLostLambda"
-    }
+    "TheLostLambda"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/pizza-pi/.meta/config.json
+++ b/exercises/concept/pizza-pi/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for pizza-pi exercise",
   "authors": [
-    {
-      "github_username": "TheLostLambda",
-      "exercism_username": "TheLostLambda"
-    },
-    {
-      "github_username": "verdammelt",
-      "exercism_username": "verdammelt"
-    }
+    "TheLostLambda",
+    "verdammelt"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/socks-and-sexprs/.meta/config.json
+++ b/exercises/concept/socks-and-sexprs/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for socks-and-sexprs exercise",
   "authors": [
-    {
-      "github_username": "verdammelt",
-      "exercism_username": "verdammelt"
-    },
-    {
-      "github_username": "TheLostLambda",
-      "exercism_username": "TheLostLambda"
-    }
+    "verdammelt",
+    "TheLostLambda"
   ],
   "files": {
     "solution": [


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
