### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "https://github.com/monkbroc",
   "source": "Julien Vanier",
   "files": {
-    "test": [
-      "acronym-test.lisp"
-    ],
-    "solution": [
-      "acronym.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["acronym-test.lisp"],
+    "solution": ["acronym.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "serialhex"
-  ],
-  "contributors": [
-    "azrazalea",
-    "daveyarwood",
-    "dnmfarrell",
-    "verdammelt",
-    "viztor"
-  ]
+  "authors": ["serialhex"],
+  "contributors": ["daveyarwood", "dnmfarrell", "verdammelt", "viztor"]
 }

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["serialhex"],
-  "contributors": ["daveyarwood", "dnmfarrell", "verdammelt", "viztor"]
+  "contributors": ["daveyarwood", "dnmfarrell", "verdammelt"]
 }

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "serialhex"
+  ],
+  "contributors": [
+    "azrazalea",
+    "daveyarwood",
+    "dnmfarrell",
+    "verdammelt",
+    "viztor"
+  ]
 }

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["serialhex"],
-  "contributors": ["daveyarwood", "dnmfarrell", "verdammelt"]
+  "contributors": ["daveyarwood", "dnmfarrell"]
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -11,5 +11,10 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "serialhex"
+  ],
+  "contributors": [
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,20 +1,10 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "files": {
-    "test": [
-      "all-your-base-test.lisp"
-    ],
-    "solution": [
-      "all-your-base.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["all-your-base-test.lisp"],
+    "solution": ["all-your-base.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "serialhex"
-  ],
-  "contributors": [
-    "verdammelt"
-  ]
+  "authors": ["serialhex"],
+  "contributors": null
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://jumpstartlab.com",
   "source": "Jumpstart Lab Warm-up",
   "files": {
-    "test": [
-      "allergies-test.lisp"
-    ],
-    "solution": [
-      "allergies.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["allergies-test.lisp"],
+    "solution": ["allergies.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "wobh"
+  ]
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "https://github.com/rchatley/extreme_startup",
   "source": "Inspired by the Extreme Startup game",
   "files": {
-    "test": [
-      "anagram-test.lisp"
-    ],
-    "solution": [
-      "anagram.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["anagram-test.lisp"],
+    "solution": ["anagram.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "spacebat",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "dnmfarrell", "spacebat", "wobh"]
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "spacebat", "wobh"]
+  "contributors": ["dnmfarrell", "spacebat"]
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "spacebat",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "dnmfarrell", "spacebat", "wobh"]
+  "contributors": ["dnmfarrell", "spacebat", "wobh"]
 }

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -13,5 +13,7 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "wobh"
+  ]
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "http://en.wikipedia.org/wiki/Atbash",
   "source": "Wikipedia",
   "files": {
-    "test": [
-      "atbash-cipher-test.lisp"
-    ],
-    "solution": [
-      "atbash-cipher.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["atbash-cipher-test.lisp"],
+    "solution": ["atbash-cipher.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
   "source": "Learn to Program by Chris Pine",
   "files": {
-    "test": [
-      "beer-song-test.lisp"
-    ],
-    "solution": [
-      "beer-song.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["beer-song-test.lisp"],
+    "solution": ["beer-song.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -3,20 +3,10 @@
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm",
   "source": "Wikipedia",
   "files": {
-    "test": [
-      "binary-search-test.lisp"
-    ],
-    "solution": [
-      "binary-search.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["binary-search-test.lisp"],
+    "solution": ["binary-search.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "wsgac"
-  ],
-  "contributors": [
-    "verdammelt"
-  ]
+  "authors": ["wsgac"],
+  "contributors": null
 }

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -13,5 +13,10 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "wsgac"
+  ],
+  "contributors": [
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
   "source": "All of Computer Science",
   "files": {
-    "test": [
-      "binary-test.lisp"
-    ],
-    "solution": [
-      "binary.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["binary-test.lisp"],
+    "solution": ["binary.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "wobh"
+  ]
 }

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["austinlyons", "azrazalea", "wobh"]
+  "contributors": ["austinlyons", "wobh"]
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["austinlyons", "wobh"]
+  "contributors": ["austinlyons"]
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06",
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "files": {
-    "test": [
-      "bob-test.lisp"
-    ],
-    "solution": [
-      "bob.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["bob-test.lisp"],
+    "solution": ["bob.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "austinlyons",
-    "azrazalea",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["austinlyons", "azrazalea", "wobh"]
 }

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "austinlyons",
+    "azrazalea",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["azrazalea", "serialhex", "verdammelt"]
+  "contributors": ["serialhex", "verdammelt"]
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -3,20 +3,10 @@
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem",
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "files": {
-    "test": [
-      "collatz-conjecture-test.lisp"
-    ],
-    "solution": [
-      "collatz-conjecture.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["collatz-conjecture-test.lisp"],
+    "solution": ["collatz-conjecture.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": null,
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "verdammelt"
-  ]
+  "authors": ["Average-user"],
+  "contributors": ["azrazalea", "serialhex", "verdammelt"]
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["serialhex", "verdammelt"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -13,5 +13,10 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": null,
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "wobh"
+  ]
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html",
   "source": "J Dalbey's Programming Practice problems",
   "files": {
-    "test": [
-      "crypto-square-test.lisp"
-    ],
-    "solution": [
-      "crypto-square.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["crypto-square-test.lisp"],
+    "solution": ["crypto-square.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["wobh"],
-  "contributors": ["dnmfarrell", "Scientifica96", "verdammelt"]
+  "contributors": ["dnmfarrell", "Scientifica96"]
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "wobh"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "Scientifica96",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://projecteuler.net/problem=6",
   "source": "Problem 6 at Project Euler",
   "files": {
-    "test": [
-      "difference-of-squares-test.lisp"
-    ],
-    "solution": [
-      "difference-of-squares.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["difference-of-squares-test.lisp"],
+    "solution": ["difference-of-squares.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "wobh"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "Scientifica96",
-    "verdammelt"
-  ]
+  "authors": ["wobh"],
+  "contributors": ["dnmfarrell", "Scientifica96", "verdammelt"]
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "sjwarner-bp"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "sjwarner-bp", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "sjwarner-bp"]
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -3,25 +3,16 @@
   "source_url": "http://jumpstartlab.com",
   "source": "The Jumpstart Lab team",
   "files": {
-    "test": [
-      "etl-test.lisp"
-    ],
-    "solution": [
-      "etl.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["etl-test.lisp"],
+    "solution": ["etl.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
+  "authors": ["verdammelt"],
   "contributors": [
     "azrazalea",
     "dnmfarrell",
     "serialhex",
     "sjwarner-bp",
-    "verdammelt",
     "wobh"
   ]
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -8,11 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "sjwarner-bp",
-    "wobh"
-  ]
+  "contributors": ["dnmfarrell", "serialhex", "sjwarner-bp", "wobh"]
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "sjwarner-bp"]
+  "contributors": ["dnmfarrell", "sjwarner-bp"]
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -13,5 +13,15 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "sjwarner-bp",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "sjwarner-bp",
+    "TatriX",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "sjwarner-bp", "TatriX", "wobh"]
+  "contributors": ["sjwarner-bp", "TatriX", "wobh"]
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["sjwarner-bp", "TatriX"]
+  "contributors": ["TatriX"]
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["sjwarner-bp", "TatriX", "wobh"]
+  "contributors": ["sjwarner-bp", "TatriX"]
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09",
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "files": {
-    "test": [
-      "gigasecond-test.lisp"
-    ],
-    "solution": [
-      "gigasecond.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["gigasecond-test.lisp"],
+    "solution": ["gigasecond.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "sjwarner-bp",
-    "TatriX",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "sjwarner-bp", "TatriX", "wobh"]
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "serialhex", "wobh"]
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://gschool.it",
   "source": "A pairing session with Phil Battos at gSchool",
   "files": {
-    "test": [
-      "grade-school-test.lisp"
-    ],
-    "solution": [
-      "grade-school.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["grade-school-test.lisp"],
+    "solution": ["grade-school.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "serialhex", "wobh"]
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["wobh"]
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "serialhex", "wobh"]
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://www.javaranch.com/grains.jsp",
   "source": "JavaRanch Cattle Drive, exercise 6",
   "files": {
-    "test": [
-      "grains-test.lisp"
-    ],
-    "solution": [
-      "grains.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["grains-test.lisp"],
+    "solution": ["grains.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "serialhex", "wobh"]
 }

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["wobh"],
-  "contributors": ["verdammelt"]
+  "contributors": null
 }

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -3,21 +3,10 @@
   "source_url": "http://rosalind.info/problems/hamm/",
   "source": "The Calculating Point Mutations problem at Rosalind",
   "files": {
-    "test": [
-      "hamming-test.lisp"
-    ],
-    "solution": [
-      "hamming.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["hamming-test.lisp"],
+    "solution": ["hamming.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "wobh"
-  ],
-  "contributors": [
-    "azrazalea",
-    "verdammelt"
-  ]
+  "authors": ["wobh"],
+  "contributors": ["verdammelt"]
 }

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -13,5 +13,11 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "wobh"
+  ],
+  "contributors": [
+    "azrazalea",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -13,5 +13,11 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "serialhex"
+  ],
+  "contributors": [
+    "azrazalea",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -3,21 +3,10 @@
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program",
   "source": "This is an exercise to introduce users to using Exercism",
   "files": {
-    "test": [
-      "hello-world-test.lisp"
-    ],
-    "solution": [
-      "hello-world.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["hello-world-test.lisp"],
+    "solution": ["hello-world.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "serialhex"
-  ],
-  "contributors": [
-    "azrazalea",
-    "verdammelt"
-  ]
+  "authors": ["serialhex"],
+  "contributors": ["verdammelt"]
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["sjwarner-bp"]
+  "contributors": null
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -13,5 +13,11 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": null,
+  "contributors": [
+    "azrazalea",
+    "sjwarner-bp",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -3,21 +3,10 @@
   "source_url": "https://en.wikipedia.org/wiki/Isogram",
   "source": "Wikipedia",
   "files": {
-    "test": [
-      "isogram-test.lisp"
-    ],
-    "solution": [
-      "isogram.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["isogram-test.lisp"],
+    "solution": ["isogram.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": null,
-  "contributors": [
-    "azrazalea",
-    "sjwarner-bp",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["Average-user"],
+  "contributors": ["azrazalea", "sjwarner-bp", "verdammelt", "wobh"]
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["sjwarner-bp", "wobh"]
+  "contributors": ["sjwarner-bp"]
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["azrazalea", "sjwarner-bp", "verdammelt", "wobh"]
+  "contributors": ["sjwarner-bp", "verdammelt", "wobh"]
 }

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["sjwarner-bp", "verdammelt", "wobh"]
+  "contributors": ["sjwarner-bp", "wobh"]
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "serialhex", "wobh"]
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://www.javaranch.com/leap.jsp",
   "source": "JavaRanch Cattle Drive, exercise 3",
   "files": {
-    "test": [
-      "leap-test.lisp"
-    ],
-    "solution": [
-      "leap.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["leap-test.lisp"],
+    "solution": ["leap.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "serialhex", "wobh"]
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "serialhex"
+  ],
+  "contributors": [
+    "chuchana",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm",
   "source": "The Luhn Algorithm on Wikipedia",
   "files": {
-    "test": [
-      "luhn-test.lisp"
-    ],
-    "solution": [
-      "luhn.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["luhn-test.lisp"],
+    "solution": ["luhn.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "serialhex"
-  ],
-  "contributors": [
-    "chuchana",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["serialhex"],
+  "contributors": ["chuchana", "wobh"]
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "https://twitter.com/copiousfreetime",
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "files": {
-    "test": [
-      "meetup-test.lisp"
-    ],
-    "solution": [
-      "meetup.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["meetup-test.lisp"],
+    "solution": ["meetup.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "sjakobi"]
+  "contributors": ["dnmfarrell", "sjakobi"]
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "sjakobi", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "sjakobi"]
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -13,5 +13,15 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "sjakobi",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "sjakobi", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "sjakobi", "wobh"]
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -3,25 +3,10 @@
   "source_url": "http://rosalind.info/problems/dna/",
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "files": {
-    "test": [
-      "nucleotide-count-test.lisp"
-    ],
-    "solution": [
-      "nucleotide-count.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["nucleotide-count-test.lisp"],
+    "solution": ["nucleotide-count.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "sjakobi",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "sjakobi", "wobh"]
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["daantjie"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["daantjie"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["daantjie"],
-  "contributors": ["serialhex", "verdammelt", "wobh"]
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html",
   "source": "Pascal's Triangle at Wolfram Math World",
   "files": {
-    "test": [
-      "pascals-triangle-test.lisp"
-    ],
-    "solution": [
-      "pascals-triangle.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["pascals-triangle-test.lisp"],
+    "solution": ["pascals-triangle.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "daantjie"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["daantjie"],
+  "contributors": ["serialhex", "verdammelt", "wobh"]
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "daantjie"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["azrazalea", "serialhex", "verdammelt"]
+  "contributors": ["serialhex", "verdammelt"]
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -3,20 +3,10 @@
   "source_url": "http://shop.oreilly.com/product/0636920029687.do",
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "files": {
-    "test": [
-      "perfect-numbers-test.lisp"
-    ],
-    "solution": [
-      "perfect-numbers.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["perfect-numbers-test.lisp"],
+    "solution": ["perfect-numbers.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": null,
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "verdammelt"
-  ]
+  "authors": ["Average-user"],
+  "contributors": ["azrazalea", "serialhex", "verdammelt"]
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["serialhex", "verdammelt"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -13,5 +13,10 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": null,
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html",
   "source": "Event Manager by JumpstartLab",
   "files": {
-    "test": [
-      "phone-number-test.lisp"
-    ],
-    "solution": [
-      "phone-number.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["phone-number-test.lisp"],
+    "solution": ["phone-number.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["wobh"],
-  "contributors": ["verdammelt"]
+  "contributors": null
 }

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -3,21 +3,10 @@
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata",
   "source": "The Prime Factors Kata by Uncle Bob",
   "files": {
-    "test": [
-      "prime-factors-test.lisp"
-    ],
-    "solution": [
-      "prime-factors.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["prime-factors-test.lisp"],
+    "solution": ["prime-factors.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "wobh"
-  ],
-  "contributors": [
-    "azrazalea",
-    "verdammelt"
-  ]
+  "authors": ["wobh"],
+  "contributors": ["verdammelt"]
 }

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -13,5 +13,11 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "wobh"
+  ],
+  "contributors": [
+    "azrazalea",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz",
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "files": {
-    "test": [
-      "raindrops-test.lisp"
-    ],
-    "solution": [
-      "raindrops.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["raindrops-test.lisp"],
+    "solution": ["raindrops.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["dnmfarrell", "wobh"]
 }

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "wobh"
+  ]
 }

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "wobh"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -7,6 +7,6 @@
     "solution": ["raindrops.lisp"],
     "example": [".meta/example.lisp"]
   },
-  "authors": ["verdammelt"],
+  "authors": ["canweriotnow"],
   "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html",
   "source": "Hyperphysics",
   "files": {
-    "test": [
-      "rna-transcription-test.lisp"
-    ],
-    "solution": [
-      "rna-transcription.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["rna-transcription-test.lisp"],
+    "solution": ["rna-transcription.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "wobh"]
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "wobh"]
+  "contributors": ["wobh"]
 }

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["wobh"]
+  "contributors": null
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -7,5 +7,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "wobh"]
+  "contributors": ["wobh"]
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -2,22 +2,10 @@
   "blurb": "Manage robot factory settings.",
   "source": "A debugging session with Paul Blackwell at gSchool.",
   "files": {
-    "test": [
-      "robot-name-test.lisp"
-    ],
-    "solution": [
-      "robot-name.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["robot-name-test.lisp"],
+    "solution": ["robot-name.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "wobh"]
 }

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -12,5 +12,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -13,5 +13,10 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "wsgac"
+  ],
+  "contributors": [
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -3,20 +3,10 @@
   "source_url": "",
   "source": "Inspired by an interview question at a famous company.",
   "files": {
-    "test": [
-      "robot-simulator-test.lisp"
-    ],
-    "solution": [
-      "robot-simulator.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["robot-simulator-test.lisp"],
+    "solution": ["robot-simulator.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "wsgac"
-  ],
-  "contributors": [
-    "verdammelt"
-  ]
+  "authors": ["wsgac"],
+  "contributors": ["verdammelt"]
 }

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["wobh"],
-  "contributors": ["dnmfarrell", "serialhex", "verdammelt"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals",
   "source": "The Roman Numeral Kata",
   "files": {
-    "test": [
-      "roman-numerals-test.lisp"
-    ],
-    "solution": [
-      "roman-numerals.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["roman-numerals-test.lisp"],
+    "solution": ["roman-numerals.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "wobh"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "verdammelt"
-  ]
+  "authors": ["wobh"],
+  "contributors": ["dnmfarrell", "serialhex", "verdammelt"]
 }

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["wobh"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors": [
+    "wobh"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -3,23 +3,10 @@
   "source_url": "https://github.com/rchatley/extreme_startup",
   "source": "Inspired by the Extreme Startup game",
   "files": {
-    "test": [
-      "scrabble-score-test.lisp"
-    ],
-    "solution": [
-      "scrabble-score.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["scrabble-score-test.lisp"],
+    "solution": ["scrabble-score.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -13,5 +13,13 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "wobh"
+  ]
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes",
   "source": "Sieve of Eratosthenes at Wikipedia",
   "files": {
-    "test": [
-      "sieve-test.lisp"
-    ],
-    "solution": [
-      "sieve.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["sieve-test.lisp"],
+    "solution": ["sieve.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "wobh"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "verdammelt"
-  ]
+  "authors": ["wobh"],
+  "contributors": ["dnmfarrell", "verdammelt"]
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["wobh"],
-  "contributors": ["dnmfarrell", "verdammelt"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "wobh"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01",
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "files": {
-    "test": [
-      "space-age-test.lisp"
-    ],
-    "solution": [
-      "space-age.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["space-age-test.lisp"],
+    "solution": ["space-age.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "https://twitter.com/jeg2",
   "source": "Conversation with James Edward Gray II",
   "files": {
-    "test": [
-      "strain-test.lisp"
-    ],
-    "solution": [
-      "strain.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["strain-test.lisp"],
+    "solution": ["strain.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["dnmfarrell", "wobh"]
 }

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "wobh"
+  ]
 }

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "wobh"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,22 +1,10 @@
 {
   "blurb": "Write a function to determine if a list is a sublist of another list.",
   "files": {
-    "test": [
-      "sublist-test.lisp"
-    ],
-    "solution": [
-      "sublist.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["sublist-test.lisp"],
+    "solution": ["sublist.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "Average-user"
-  ],
-  "contributors": [
-    "azrazalea",
-    "kephas",
-    "verdammelt"
-  ]
+  "authors": ["Average-user"],
+  "contributors": ["kephas", "verdammelt"]
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -11,5 +11,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "Average-user"
+  ],
+  "contributors": [
+    "azrazalea",
+    "kephas",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -6,5 +6,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["Average-user"],
-  "contributors": ["kephas", "verdammelt"]
+  "contributors": ["kephas"]
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex"]
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -13,5 +13,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "dnmfarrell",
+    "serialhex",
+    "verdammelt",
+    "wobh"
+  ]
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["dnmfarrell", "serialhex", "wobh"]
+  "contributors": ["dnmfarrell", "serialhex"]
 }

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -3,24 +3,10 @@
   "source_url": "http://rubykoans.com",
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "files": {
-    "test": [
-      "triangle-test.lisp"
-    ],
-    "solution": [
-      "triangle.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["triangle-test.lisp"],
+    "solution": ["triangle.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "dnmfarrell",
-    "serialhex",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "dnmfarrell", "serialhex", "wobh"]
 }

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex"]
+  "contributors": null
 }

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -3,22 +3,10 @@
   "source_url": "http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-",
   "source": "All of Computer Science",
   "files": {
-    "test": [
-      "trinary-test.lisp"
-    ],
-    "solution": [
-      "trinary.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["trinary-test.lisp"],
+    "solution": ["trinary.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["serialhex", "wobh"]
 }

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -13,5 +13,12 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "wobh"
+  ]
 }

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -8,5 +8,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "wobh"]
+  "contributors": ["serialhex"]
 }

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -13,5 +13,11 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "serialhex"
+  ],
+  "contributors": [
+    "dnmfarrell",
+    "verdammelt"
+  ]
 }

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -3,21 +3,10 @@
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)",
   "source": "Wikipedia",
   "files": {
-    "test": [
-      "twelve-days-test.lisp"
-    ],
-    "solution": [
-      "twelve-days.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["twelve-days-test.lisp"],
+    "solution": ["twelve-days.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "serialhex"
-  ],
-  "contributors": [
-    "dnmfarrell",
-    "verdammelt"
-  ]
+  "authors": ["serialhex"],
+  "contributors": ["dnmfarrell"]
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -2,21 +2,10 @@
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "source_url": "https://github.com/exercism/problem-specifications/issues/757",
   "files": {
-    "test": [
-      "two-fer-test.lisp"
-    ],
-    "solution": [
-      "two-fer.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["two-fer-test.lisp"],
+    "solution": ["two-fer.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "verdammelt"
-  ],
-  "contributors": [
-    "OrdoFlammae",
-    "timotheosh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["OrdoFlammae", "timotheosh"]
 }

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -12,5 +12,11 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": null
+  "authors": [
+    "verdammelt"
+  ],
+  "contributors": [
+    "OrdoFlammae",
+    "timotheosh"
+  ]
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -2,24 +2,10 @@
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.",
   "files": {
-    "test": [
-      "word-count-test.lisp"
-    ],
-    "solution": [
-      "word-count.lisp"
-    ],
-    "example": [
-      ".meta/example.lisp"
-    ]
+    "test": ["word-count-test.lisp"],
+    "solution": ["word-count.lisp"],
+    "example": [".meta/example.lisp"]
   },
-  "authors": [
-    "kytrinyx"
-  ],
-  "contributors": [
-    "azrazalea",
-    "serialhex",
-    "spacebat",
-    "verdammelt",
-    "wobh"
-  ]
+  "authors": ["verdammelt"],
+  "contributors": ["azrazalea", "serialhex", "spacebat", "wobh"]
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -7,5 +7,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["azrazalea", "serialhex", "spacebat", "wobh"]
+  "contributors": ["serialhex", "spacebat", "wobh"]
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -7,5 +7,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "spacebat", "wobh"]
+  "contributors": ["serialhex", "spacebat"]
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -7,5 +7,5 @@
     "example": [".meta/example.lisp"]
   },
   "authors": ["verdammelt"],
-  "contributors": ["serialhex", "spacebat"]
+  "contributors": ["spacebat"]
 }

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -12,5 +12,14 @@
       ".meta/example.lisp"
     ]
   },
-  "authors": []
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "azrazalea",
+    "serialhex",
+    "spacebat",
+    "verdammelt",
+    "wobh"
+  ]
 }


### PR DESCRIPTION
With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercises' `.meta/config.json` files (see [the docs](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, already contain authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Maintainer TODO list

These are the things you, the maintainers, should do:

- [X] Check the authors, adding/removing users where the data is missing or incorrect
- [X] Check the contributors, adding/removing users where the data is missing or incorrect
- [X] Double-check any renamed Practice Exercises
- [X] Check for Practice Exercises with missing authors, which are most likely due to the author not being on GitHub anymore 
- [X] Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

**For clarity, authors should be the people who originally created the exercise on this track. Contributors should be people who have substantially contributed to that exercise. PRs for typos or multiple-exercise PRs do not automatically mean someone should be considered a contributor to that exercise. Those non-exercise-specific contributions will get recognition through Exercism's reputation system in v3.**

If you find something needs updating, just push a new commit to this PR.

## Automatic Merging

We will automatically merge this PR before we launch v3, but will give the maximum time we can to maintainers to review it first.

---

_The rest of this issue explains how this PR has been generated. You do not **need** to read it._

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits touched that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Any commit that we can associate with a Practice Exercise is used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise.
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors and any co-authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author and any co-authors of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors and any co-authors of those commits
3. Add the GitHub usernames of the Git commit authors and any co-authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author and any co-authors. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There are a small number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Tracking

https://github.com/exercism/v3-launch/issues/24

---

cc @austinlyons, @Average-user, @azrazalea, @chuchana, @daantjie, @daveyarwood, @dnmfarrell, @kephas, @kytrinyx, @OrdoFlammae, @Scientifica96, @serialhex, @sjakobi, @sjwarner-bp, @spacebat, @TatriX, @timotheosh, @verdammelt, @viztor, @wobh, @wsgac as you are referenced in this PR