### PR TITLE
Replace `NIL` with `()` in stub function definition.

### DIFF
--- a/exercises/practice/hello-world/hello-world.lisp
+++ b/exercises/practice/hello-world/hello-world.lisp
@@ -3,4 +3,4 @@
   (:export #:hello))
 (in-package #:hello-world)
 
-(defun hello NIL)
+(defun hello ())


### PR DESCRIPTION
While equivalent, definitely not idiomatic.

Fixes #377.