### PR TITLE
Remove string as a concept that this exercise depends upon.

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,13 +66,7 @@
         "name": "Pal Picker",
         "uuid": "c0155014-4d11-4cb2-872b-6dfdf794f7cd",
         "concepts": ["conditionals", "truthy-and-falsy"],
-        "prerequisites": [
-          "expressions",
-          "integers",
-          "arithmetic",
-          "symbols",
-          "strings"
-        ],
+        "prerequisites": ["expressions", "integers", "arithmetic", "symbols"],
         "status": "beta"
       },
       {

--- a/exercises/concept/pal-picker/.meta/design.md
+++ b/exercises/concept/pal-picker/.meta/design.md
@@ -28,4 +28,3 @@
 - `integers`
 - `arithmetic`
 - `symbols`
-- `strings`


### PR DESCRIPTION
pal-picker is a very early concept exercise and having string as a
concept it depended upon blocked access to it. The string concept
exercise will likely need to depend upon concepts like conditionals so
it would not have been easy to wedge the string concept in earlier in
the graph.