### PR TITLE
Remove traces of v2 test runner from CI

### DIFF
--- a/src/test-exercises/exercises.lisp
+++ b/src/test-exercises/exercises.lisp
@@ -9,8 +9,8 @@
   (destructuring-bind (type slug)
       (mapcar #'keywordize (last (pathname-directory dir) 2))
     (let ((config (slurp-exercise-config dir)))
-      (pairlis '(:directory :type :slug :files :v2)
-               (list dir type slug (aget :files config) (aget :v2 config))))))
+      (pairlis '(:directory :type :slug :files)
+               (list dir type slug (aget :files config))))))
 
 (defun load-exercise-file (exercise file)
   (let ((*default-pathname-defaults* (aget :directory exercise))

--- a/src/test-exercises/run.lisp
+++ b/src/test-exercises/run.lisp
@@ -1,27 +1,10 @@
 (in-package #:test-exercises)
 
-;; for v2 test running
-(pushnew :xlisp-test *features*)
-
 (defun example-files (data)
   (or (aget :exemplar (aget :files data))
       (aget :example (aget :files data))))
 
-(defun test-v2-exercise (data)
-  (let ((test-files (aget :test (aget :files data)))
-        (solution-files (aget :solution (aget :files data)))
-        (exemplar-files (example-files data)))
-    (unwind-protect
-         (progn
-           (dolist (f (append solution-files exemplar-files test-files))
-             (load-exercise-file data f))
-           (list
-            (let ((lisp-unit:*summarize-results* nil))
-              (lisp-unit:run-tests :all (find-exercise-package data :test t)))))
-      (delete-package (find-exercise-package data :test t))
-      (delete-package (find-exercise-package data)))))
-
-(defun test-v3-exercise (data)
+(defun %test-exercise (data)
   (let ((test-files (aget :test (aget :files data)))
         (exemplar-files (example-files data)))
     (unwind-protect
@@ -41,7 +24,5 @@
     (pairlis '(:exercise :results)
              (list data
                    (handler-case
-                       (if (aget :v2 data)
-                           (test-v2-exercise data)
-                           (test-v3-exercise data))
+                       (%test-exercise data)
                      (error (c) (list c)))))))


### PR DESCRIPTION
This code is simply no longer needed.