### PR TITLE
Remove canonical data syncer reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 tmp
 bin/configlet
 bin/configlet.exe
-bin/canonical_data_syncer
-bin/canonical_data_syncer.exe
 bin/generate-exercise
 *~
 .mailmap


### PR DESCRIPTION
The `fetch-canonical-data-syncer` script is obsolete as canonical data syncing is now built into `configlet`.

See https://github.com/exercism/configlet/issues/124