### PR TITLE
🤖 Add average test runner run time to `config.json`

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,11 +16,22 @@
     "ace_editor_language": "lisp",
     "highlightjs_language": "lisp"
   },
+  "test_runner": {
+    "average_run_time": 2.0
+  },
   "files": {
-    "solution": ["./%{kebab_slug}.lisp"],
-    "test": ["./%{kebab_slug}-test.lisp"],
-    "example": ["./.meta/example.lisp"],
-    "exemplar": ["./.meta/exempler.lisp"]
+    "solution": [
+      "./%{kebab_slug}.lisp"
+    ],
+    "test": [
+      "./%{kebab_slug}-test.lisp"
+    ],
+    "example": [
+      "./.meta/example.lisp"
+    ],
+    "exemplar": [
+      "./.meta/exempler.lisp"
+    ]
   },
   "exercises": {
     "concept": [
@@ -28,7 +39,12 @@
         "slug": "socks-and-sexprs",
         "name": "Sorting Socks and Sexprs",
         "uuid": "6787f07b-6fca-48ec-9ed1-f37bb77126f2",
-        "concepts": ["comments", "expressions", "cons", "symbols"],
+        "concepts": [
+          "comments",
+          "expressions",
+          "cons",
+          "symbols"
+        ],
         "prerequisites": [],
         "status": "beta"
       },
@@ -36,7 +52,9 @@
         "slug": "key-comparison",
         "name": "The Key to Comparison",
         "uuid": "8d7ba0dc-7d87-452c-8208-39491d8f40f4",
-        "concepts": ["sameness"],
+        "concepts": [
+          "sameness"
+        ],
         "prerequisites": [
           "characters",
           "strings",
@@ -51,32 +69,58 @@
         "slug": "pizza-pi",
         "name": "Pizza Pi",
         "uuid": "f78cff23-2106-4e35-b439-2d8bd2830770",
-        "concepts": ["integers", "floating-point-numbers", "arithmetic"],
-        "prerequisites": ["expressions"],
+        "concepts": [
+          "integers",
+          "floating-point-numbers",
+          "arithmetic"
+        ],
+        "prerequisites": [
+          "expressions"
+        ],
         "status": "beta"
       },
       {
         "slug": "leslies-lists",
         "name": "Leslie's Lengthy Lists",
         "uuid": "fd1aaa1a-f3c0-419e-a713-761c5147a5e1",
-        "concepts": ["lists"],
-        "prerequisites": ["cons", "symbols", "arithmetic"],
+        "concepts": [
+          "lists"
+        ],
+        "prerequisites": [
+          "cons",
+          "symbols",
+          "arithmetic"
+        ],
         "status": "beta"
       },
       {
         "slug": "pal-picker",
         "name": "Pal Picker",
         "uuid": "c0155014-4d11-4cb2-872b-6dfdf794f7cd",
-        "concepts": ["conditionals", "truthy-and-falsy"],
-        "prerequisites": ["expressions", "integers", "arithmetic", "symbols"],
+        "concepts": [
+          "conditionals",
+          "truthy-and-falsy"
+        ],
+        "prerequisites": [
+          "expressions",
+          "integers",
+          "arithmetic",
+          "symbols"
+        ],
         "status": "beta"
       },
       {
         "slug": "lillys-lasagna",
         "name": "Lilly's Lasagna",
         "uuid": "60f4773a-e37e-4186-8542-a19ffbf6e6ae",
-        "concepts": ["functions"],
-        "prerequisites": ["expressions", "integers", "arithmetic"],
+        "concepts": [
+          "functions"
+        ],
+        "prerequisites": [
+          "expressions",
+          "integers",
+          "arithmetic"
+        ],
         "status": "beta"
       },
       {
@@ -89,15 +133,24 @@
           "default-parameters",
           "rest-parameters"
         ],
-        "prerequisites": ["functions", "symbols", "conditionals"],
+        "prerequisites": [
+          "functions",
+          "symbols",
+          "conditionals"
+        ],
         "status": "beta"
       },
       {
         "slug": "log-levels",
         "name": "Log Levels",
         "uuid": "50b5e2a8-d13f-43c6-8481-78270ecf1591",
-        "concepts": ["strings"],
-        "prerequisites": ["conditionals", "symbols"],
+        "concepts": [
+          "strings"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "symbols"
+        ],
         "status": "beta"
       }
     ],
@@ -115,7 +168,11 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "b80ab7d9-6152-4351-b405-07c2fb071962",
-        "practices": ["default-parameters", "text-formatting", "conditionals"],
+        "practices": [
+          "default-parameters",
+          "text-formatting",
+          "conditionals"
+        ],
         "prerequisites": [
           "expressions",
           "functions",
@@ -153,8 +210,15 @@
         "name": "Rna Transcription",
         "uuid": "5c215cbf-a575-42ad-9b3f-892410a63077",
         "difficulty": 1,
-        "practices": ["conditionals", "strings"],
-        "prerequisites": ["functions", "iteration", "strings"],
+        "practices": [
+          "conditionals",
+          "strings"
+        ],
+        "prerequisites": [
+          "functions",
+          "iteration",
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -162,8 +226,16 @@
         "name": "Leap",
         "uuid": "8bfa54a8-4ee6-4e6e-b286-7fc8c70b9e9f",
         "difficulty": 1,
-        "practices": ["conditionals", "sameness", "integers"],
-        "prerequisites": ["conditionals", "arithmetic", "integers"],
+        "practices": [
+          "conditionals",
+          "sameness",
+          "integers"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "arithmetic",
+          "integers"
+        ],
         "status": "beta"
       },
       {
@@ -171,8 +243,16 @@
         "name": "Anagram",
         "uuid": "b9fd0f13-966c-4085-ac9d-ed49a96ac0bf",
         "difficulty": 1,
-        "practices": ["sameness", "filtering", "strings"],
-        "prerequisites": ["functions", "strings", "iteration"],
+        "practices": [
+          "sameness",
+          "filtering",
+          "strings"
+        ],
+        "prerequisites": [
+          "functions",
+          "strings",
+          "iteration"
+        ],
         "status": "beta"
       },
       {
@@ -186,7 +266,11 @@
           "iteration",
           "text-formatting"
         ],
-        "prerequisites": ["conditionals", "text-formatting", "iteration"],
+        "prerequisites": [
+          "conditionals",
+          "text-formatting",
+          "iteration"
+        ],
         "status": "beta"
       },
       {
@@ -201,7 +285,12 @@
           "strings",
           "text-formatting"
         ],
-        "prerequisites": ["functions", "arithmetic", "integers", "iteration"],
+        "prerequisites": [
+          "functions",
+          "arithmetic",
+          "integers",
+          "iteration"
+        ],
         "status": "beta"
       },
       {
@@ -209,8 +298,17 @@
         "name": "Word Count",
         "uuid": "424ed7aa-24f3-4aec-9620-3cc9dc224166",
         "difficulty": 2,
-        "practices": ["conditionals", "filtering", "iteration", "strings"],
-        "prerequisites": ["strings", "iteration", "conditionals"],
+        "practices": [
+          "conditionals",
+          "filtering",
+          "iteration",
+          "strings"
+        ],
+        "prerequisites": [
+          "strings",
+          "iteration",
+          "conditionals"
+        ],
         "status": "beta"
       },
       {
@@ -218,8 +316,14 @@
         "name": "Bob",
         "uuid": "1e6c8365-775d-4a4f-8fc7-e376912d7912",
         "difficulty": 1,
-        "practices": ["conditionals", "strings"],
-        "prerequisites": ["conditionals", "strings"],
+        "practices": [
+          "conditionals",
+          "strings"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -227,8 +331,16 @@
         "name": "Twelve Days",
         "uuid": "40ce6656-b8f5-4156-94b6-d634876215b2",
         "difficulty": 4,
-        "practices": ["strings", "text-formatting", "iteration"],
-        "prerequisites": ["strings", "text-formatting", "iteration"],
+        "practices": [
+          "strings",
+          "text-formatting",
+          "iteration"
+        ],
+        "prerequisites": [
+          "strings",
+          "text-formatting",
+          "iteration"
+        ],
         "status": "beta"
       },
       {
@@ -236,8 +348,12 @@
         "name": "Acronym",
         "uuid": "a999c375-f2e2-4d47-a9e2-5af923cd46d1",
         "difficulty": 1,
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -245,8 +361,14 @@
         "name": "All Your Base",
         "uuid": "9b01a3bd-68fe-4171-8e5e-ff3351865aaf",
         "difficulty": 1,
-        "practices": ["integers", "arithmetic"],
-        "prerequisites": ["integers", "arithmetic"],
+        "practices": [
+          "integers",
+          "arithmetic"
+        ],
+        "prerequisites": [
+          "integers",
+          "arithmetic"
+        ],
         "status": "beta"
       },
       {
@@ -273,8 +395,16 @@
         "name": "Armstrong Numbers",
         "uuid": "9319d1a6-276f-4b3b-8305-fc022cc48ef2",
         "difficulty": 1,
-        "practices": ["integers", "lists", "arithmetic"],
-        "prerequisites": ["integers", "lists", "arithmetic"],
+        "practices": [
+          "integers",
+          "lists",
+          "arithmetic"
+        ],
+        "prerequisites": [
+          "integers",
+          "lists",
+          "arithmetic"
+        ],
         "status": "beta"
       },
       {
@@ -301,8 +431,16 @@
         "name": "Binary Search",
         "uuid": "b327bd9a-b12e-490b-91cb-d3c21a23b4eb",
         "difficulty": 1,
-        "practices": ["iteration", "sequences", "strings"],
-        "prerequisites": ["iteration", "sequences", "strings"],
+        "practices": [
+          "iteration",
+          "sequences",
+          "strings"
+        ],
+        "prerequisites": [
+          "iteration",
+          "sequences",
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -310,8 +448,16 @@
         "name": "Collatz Conjecture",
         "uuid": "b3ad38c2-2962-4b47-9b14-20ca262ebff6",
         "difficulty": 1,
-        "practices": ["integers", "arithmetic", "recursion"],
-        "prerequisites": ["integers", "arithmetic", "recursion"],
+        "practices": [
+          "integers",
+          "arithmetic",
+          "recursion"
+        ],
+        "prerequisites": [
+          "integers",
+          "arithmetic",
+          "recursion"
+        ],
         "status": "beta"
       },
       {
@@ -338,8 +484,14 @@
         "name": "Etl",
         "uuid": "52ac3dd0-8803-445f-93cf-e984b59d6702",
         "difficulty": 1,
-        "practices": ["iteration", "mapping"],
-        "prerequisites": ["iteration", "mapping"],
+        "practices": [
+          "iteration",
+          "mapping"
+        ],
+        "prerequisites": [
+          "iteration",
+          "mapping"
+        ],
         "status": "beta"
       },
       {
@@ -347,8 +499,16 @@
         "name": "Gigasecond",
         "uuid": "25506c31-7274-402a-95e1-8475fcdb34e1",
         "difficulty": 1,
-        "practices": ["dates-times", "integers", "variables"],
-        "prerequisites": ["dates-times", "integers", "variables"],
+        "practices": [
+          "dates-times",
+          "integers",
+          "variables"
+        ],
+        "prerequisites": [
+          "dates-times",
+          "integers",
+          "variables"
+        ],
         "status": "beta"
       },
       {
@@ -356,8 +516,14 @@
         "name": "Grains",
         "uuid": "eb3a92bf-0748-4406-ba67-9e27e367ae45",
         "difficulty": 1,
-        "practices": ["integers", "variables"],
-        "prerequisites": ["integers", "variables"],
+        "practices": [
+          "integers",
+          "variables"
+        ],
+        "prerequisites": [
+          "integers",
+          "variables"
+        ],
         "status": "beta"
       },
       {
@@ -365,8 +531,12 @@
         "name": "Isogram",
         "uuid": "89ea51d0-3f7e-4e07-8e2b-4dde4c76608b",
         "difficulty": 1,
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -374,8 +544,18 @@
         "name": "Nucleotide Count",
         "uuid": "b2ad38c2-2962-4a47-9b14-20ca262ebff6",
         "difficulty": 1,
-        "practices": ["iteration", "mapping", "sorting", "strings"],
-        "prerequisites": ["iteration", "mapping", "sorting", "strings"],
+        "practices": [
+          "iteration",
+          "mapping",
+          "sorting",
+          "strings"
+        ],
+        "prerequisites": [
+          "iteration",
+          "mapping",
+          "sorting",
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -383,8 +563,18 @@
         "name": "Pascals Triangle",
         "uuid": "34bc4fbe-f148-4519-a699-91efed432703",
         "difficulty": 1,
-        "practices": ["integers", "iteration", "arithmetic", "sequences"],
-        "prerequisites": ["integers", "iteration", "arithmetic", "sequences"],
+        "practices": [
+          "integers",
+          "iteration",
+          "arithmetic",
+          "sequences"
+        ],
+        "prerequisites": [
+          "integers",
+          "iteration",
+          "arithmetic",
+          "sequences"
+        ],
         "status": "beta"
       },
       {
@@ -392,8 +582,12 @@
         "name": "Perfect Numbers",
         "uuid": "b3ad38c2-2962-4b47-9b15-15ca262ebff6",
         "difficulty": 1,
-        "practices": ["arithmetic"],
-        "prerequisites": ["arithmetic"],
+        "practices": [
+          "arithmetic"
+        ],
+        "prerequisites": [
+          "arithmetic"
+        ],
         "status": "beta"
       },
       {
@@ -401,8 +595,16 @@
         "name": "Raindrops",
         "uuid": "b5345fcb-d4cc-4ea0-b1b9-f1b0cb92f05c",
         "difficulty": 1,
-        "practices": ["conditionals", "filtering", "integers"],
-        "prerequisites": ["conditionals", "filtering", "integers"],
+        "practices": [
+          "conditionals",
+          "filtering",
+          "integers"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "filtering",
+          "integers"
+        ],
         "status": "beta"
       },
       {
@@ -410,8 +612,16 @@
         "name": "Scrabble Score",
         "uuid": "f350f23d-72f8-4f47-a0f5-fe3c00f3f5f1",
         "difficulty": 1,
-        "practices": ["iteration", "mapping", "strings"],
-        "prerequisites": ["iteration", "mapping", "strings"],
+        "practices": [
+          "iteration",
+          "mapping",
+          "strings"
+        ],
+        "prerequisites": [
+          "iteration",
+          "mapping",
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -442,8 +652,12 @@
         "name": "Space Age",
         "uuid": "d24cf0ea-876f-4775-969b-99970425e413",
         "difficulty": 1,
-        "practices": ["floating-point-numbers"],
-        "prerequisites": ["floating-point-numbers"],
+        "practices": [
+          "floating-point-numbers"
+        ],
+        "prerequisites": [
+          "floating-point-numbers"
+        ],
         "status": "beta"
       },
       {
@@ -451,7 +665,12 @@
         "name": "Strain",
         "uuid": "1a81aac9-9128-48ab-aa6a-4d981d6eb602",
         "difficulty": 1,
-        "practices": ["conditionals", "filtering", "iteration", "sequences"],
+        "practices": [
+          "conditionals",
+          "filtering",
+          "iteration",
+          "sequences"
+        ],
         "prerequisites": [
           "conditionals",
           "filtering",
@@ -465,8 +684,12 @@
         "name": "Sublist",
         "uuid": "428e5b28-31b6-4c84-8eae-d7753d45efc1",
         "difficulty": 1,
-        "practices": ["lists"],
-        "prerequisites": ["lists"],
+        "practices": [
+          "lists"
+        ],
+        "prerequisites": [
+          "lists"
+        ],
         "status": "beta"
       },
       {
@@ -493,8 +716,16 @@
         "name": "Trinary",
         "uuid": "ff3eb2c5-c7ce-4352-805c-e01d4fb85aa6",
         "difficulty": 1,
-        "practices": ["conditionals", "integers", "arithmetic"],
-        "prerequisites": ["conditionals", "integers", "arithmetic"],
+        "practices": [
+          "conditionals",
+          "integers",
+          "arithmetic"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "integers",
+          "arithmetic"
+        ],
         "status": "beta"
       },
       {
@@ -502,8 +733,16 @@
         "name": "Atbash Cipher",
         "uuid": "71a1fdb6-414e-452c-8d24-03f2a5621e62",
         "difficulty": 2,
-        "practices": ["conditionals", "iteration", "sequences"],
-        "prerequisites": ["conditionals", "iteration", "sequences"],
+        "practices": [
+          "conditionals",
+          "iteration",
+          "sequences"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "iteration",
+          "sequences"
+        ],
         "status": "beta"
       },
       {
@@ -511,8 +750,18 @@
         "name": "Grade School",
         "uuid": "841641f2-16ba-4dc5-af1b-ffae5052853a",
         "difficulty": 2,
-        "practices": ["lists", "mapping", "sorting", "variables"],
-        "prerequisites": ["lists", "mapping", "sorting", "variables"],
+        "practices": [
+          "lists",
+          "mapping",
+          "sorting",
+          "variables"
+        ],
+        "prerequisites": [
+          "lists",
+          "mapping",
+          "sorting",
+          "variables"
+        ],
         "status": "beta"
       },
       {
@@ -520,8 +769,12 @@
         "name": "Phone Number",
         "uuid": "d1d86b51-a3f4-4276-a18c-6db54bc8dfcc",
         "difficulty": 2,
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -552,8 +805,16 @@
         "name": "Robot Name",
         "uuid": "79a4a35c-40d6-4e2d-92a1-005c40b4f4c5",
         "difficulty": 2,
-        "practices": ["randomness", "strings", "variables"],
-        "prerequisites": ["randomness", "strings", "variables"],
+        "practices": [
+          "randomness",
+          "strings",
+          "variables"
+        ],
+        "prerequisites": [
+          "randomness",
+          "strings",
+          "variables"
+        ],
         "status": "beta"
       },
       {
@@ -561,8 +822,16 @@
         "name": "Robot Simulator",
         "uuid": "d218cf9e-3b35-4357-9734-87142c22d551",
         "difficulty": 2,
-        "practices": ["iteration", "sequences", "strings"],
-        "prerequisites": ["iteration", "sequences", "strings"],
+        "practices": [
+          "iteration",
+          "sequences",
+          "strings"
+        ],
+        "prerequisites": [
+          "iteration",
+          "sequences",
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -570,8 +839,18 @@
         "name": "Crypto Square",
         "uuid": "fcfc6b44-597d-4a03-bf02-6be5c8f7ae4e",
         "difficulty": 3,
-        "practices": ["arrays", "conditionals", "iteration", "strings"],
-        "prerequisites": ["arrays", "conditionals", "iteration", "strings"],
+        "practices": [
+          "arrays",
+          "conditionals",
+          "iteration",
+          "strings"
+        ],
+        "prerequisites": [
+          "arrays",
+          "conditionals",
+          "iteration",
+          "strings"
+        ],
         "status": "beta"
       },
       {
@@ -579,8 +858,16 @@
         "name": "Meetup",
         "uuid": "6c702aa9-70f3-41d0-bc76-4323a08f8fbf",
         "difficulty": 3,
-        "practices": ["conditionals", "dates-times", "filtering"],
-        "prerequisites": ["conditionals", "dates-times", "filtering"],
+        "practices": [
+          "conditionals",
+          "dates-times",
+          "filtering"
+        ],
+        "prerequisites": [
+          "conditionals",
+          "dates-times",
+          "filtering"
+        ],
         "status": "beta"
       },
       {
@@ -588,12 +875,19 @@
         "name": "Luhn",
         "uuid": "7cc9d827-b08e-437d-826e-244f220feca0",
         "difficulty": 5,
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "status": "beta"
       }
     ],
-    "foregone": ["accumulate", "bank-account"]
+    "foregone": [
+      "accumulate",
+      "bank-account"
+    ]
   },
   "concepts": [
     {


### PR DESCRIPTION
**We will auto-merge this PR shortly. No action is required**

---

This PR adds a new `test_runner.average_run_time` key to the `config.json` file. The purpose of this field is allow the website to show a progress bar while the test runner runs. The average run time is defined in seconds with one digit of precision.

For more information, see https://github.com/exercism/docs/pull/130

We've pre-populated the average run time value by timing the execution time of the test runner in Docker on the example solution of the `leap` exercise, repeating that 4 more times, and then averaging the execution times. Clearly, the actual average execution time will differ between exercises and solutions, so this should be seen as very general indicator.

*This is mostly a stop-gap solution for now. We'll revisit this in 6 months time or so.* 

## Tracking

https://github.com/exercism/v3-launch/issues/35
