### PR TITLE
Remove matjax

### DIFF
--- a/exercises/concept/pizza-pi/.docs/approaches.md
+++ b/exercises/concept/pizza-pi/.docs/approaches.md
@@ -2,7 +2,8 @@
 
 ## A More Idiomatic Approach
 
-While this exercise encouraged the use of `=` in solving the final task (in order to introduce the comparison operators), the standard provides a number of predicates that can replace the expression you wrote with `mod` and `=`. The equation from the final task might be more idiomatically written as:
+While this exercise encouraged the use of `=` in solving the final task (in order to introduce the comparison operators), the standard provides a number of predicates that can replace the expression you wrote with `mod` and `=`.
+The equation from the final task might be more idiomatically written as:
 
 ```lisp
 (zerop (mod (* pizzas 8) friends))

--- a/exercises/concept/pizza-pi/.docs/hints.md
+++ b/exercises/concept/pizza-pi/.docs/hints.md
@@ -2,32 +2,26 @@
 
 ## General
 
-- It might be useful to have a list of all of the numeric operations in Lisp –
-  you can find a [full list here](http://l1sp.org/cl/12.1.1)
+- It might be useful to have a list of all of the numeric operations in Lisp.
+– you can find a [full list here](http://l1sp.org/cl/12.1.1)
 
 ## 1. A Dough Ratio
 
-- Common Lisp has [a built-in constant](http://l1sp.org/cl/pi) for π (pi)
+- Common Lisp has [a built-in constant](http://l1sp.org/cl/pi) for π (pi) 
 - When it comes to rounding, the CL spec provides [a smattering of
   functions](http://l1sp.org/cl/floor)
 
 ## 2. A Splash of Sauce
 
-- There is [a built-in operator](http://l1sp.org/cl/sqrt) that might help you
-  take the square-root of a number
+- There is [a built-in operator](http://l1sp.org/cl/sqrt) that might help you take the square-root of a number
 
 ## 3. Some Cheese, Please
 
-- For squaring or cubing numbers, there is a [built-in exponentiation
-  function](http://l1sp.org/cl/expt)
-- You might want to take a look at [this page of rounding
-  operations](http://l1sp.org/cl/floor) and check out some of the alternatives
-  to `round`.
+- For squaring or cubing numbers, there is a [built-in exponentiation function](http://l1sp.org/cl/expt)
+- You might want to take a look at [this page of rounding   operations](http://l1sp.org/cl/floor) and check out some of the alternatives to `round`.
 
 ## 4. A Fair Share
 
-- This part requires using a function you may not have come across before, the
-  [modulo function](https://en.wikipedia.org/wiki/Modulo_operation) (`mod`). This
-  function gives you the remainder of the division between two numbers.
-- For comparing the result of `mod` to another number, [this page of comparison
-  operators](http://l1sp.org/cl/=).
+- This part requires using a function you may not have come across before, the [modulo
+function](https://en.wikipedia.org/wiki/Modulo_operation) (`mod`). This function gives you the remainder of the division between two numbers.
+- For comparing the result of `mod` to another number, [this page of comparison operators](http://l1sp.org/cl/=).

--- a/exercises/concept/pizza-pi/.docs/instructions.md
+++ b/exercises/concept/pizza-pi/.docs/instructions.md
@@ -1,79 +1,64 @@
 # Instructions
 
-Lilly, a culinarily-inclined Lisp Alien, wants to throw a pizza party for
-themselves and some friends but, wanting to make the most of their ingredients, would
-like to know exactly how much of each component they'll need before starting.
+Lilly, a culinarily-inclined Lisp Alien, wants to throw a pizza party for themselves and some friends but, wanting to make the most of their ingredients, would like to know exactly how much of each component they'll need before starting.
 
-To solve this problem, Lilly has drafted a program to automate some of the
-planning but needs your help finishing it. Will you help Lilly throw the
-proportionally perfect pizza party?
+To solve this problem, Lilly has drafted a program to automate some of the planning but needs your help finishing it.
+Will you help Lilly throw the proportionally perfect pizza party?
 
 ## 1. A Dough Ratio
 
-First things first, every great pizza starts with a delicious dough! Lilly is a
-fan of thin, crispy pizzas with a thicker crust, so the amount of dough needed
-for the middle of the pizza remains relatively constant (200g) but the amount
-needed for the crust increases as the pizza's size does. Every 20cm of crust
-requires 45g of dough.
+First things first, every great pizza starts with a delicious dough!
+Lilly is a fan of thin, crispy pizzas with a thicker crust, so the amount of dough needed for the middle of the pizza remains relatively constant (200g) but the amount needed for the crust increases as the pizza's size does.
+Every 20cm of crust requires 45g of dough.
 
-Lilly is looking to write a function that takes the number of pizzas to make and
-their diameters then returns the exact amount of dough (to the nearest gram)
-that they'll need. For example, to make 4 pizzas 30cm in diameter:
+Lilly is looking to write a function that takes the number of pizzas to make and their diameters then returns the exact amount of dough (to the nearest gram) that they'll need.
+For example, to make 4 pizzas 30cm in diameter:
 
 ```lisp
 (dough-calculator 4 30) ; => 1648
 ```
 
-Helpfully, Lilly has worked out the following equation for calculating grams of
-dough (g) from the number of pizzas (n) and their diameters (d):
+Helpfully, Lilly has worked out the following equation for calculating grams of dough (g) from the number of pizzas (n) and their diameters (d): 
 
 $$g = n \cdot \left(\dfrac{45 \pi d}{20} + 200\right)$$
 
 ## 2. A Splash of Sauce
 
-Lilly is astonishingly meticulous when it comes to their sauce application and
-always applies exactly 3ml of sauce to every 10 square centimeters of
-pizza. Ironically, the size of their pizzas can be incredibly inconsistent. Lilly
-needs your help defining a function that calculates the pizza size (the
-diameter) from the amount of sauce applied. For example, given Lilly has used
-250ml of sauce:
+Lilly is astonishingly meticulous when it comes to their sauce application and always applies exactly 3ml of sauce to every 10 square centimeters of pizza.
+Ironically, the size of their pizzas can be incredibly inconsistent.
+Lilly needs your help defining a function that calculates the pizza size (the diameter) from the amount of sauce applied.
+For example, given Lilly has used 250ml of sauce:
 
 ```lisp
 (size-from-sauce 250) ; => 32.57
 ```
 
-For this task, Lilly has prepped the following equation relating milliliters of
-sauce applied (s) to the pizza diameter (d):
+For this task, Lilly has prepped the following equation relating milliliters of sauce applied (s) to the pizza diameter (d): 
 
 $$d = \sqrt{\dfrac{40s}{3\pi}}$$
 
 ## 3. Some Cheese, Please
 
-On Lilly's planet, all cheese comes in perfect cubes and is sold by size. (What
-were you expecting? This is an alien planet after all...) Your task is to help
-Lilly calculate how many pizzas they can make using any given cheese
-cube. Mozzarella cheese has a density of 0.5 grams per cubic centimeter and
-every pizza needs 3 grams of cheese per square centimeter. Given the side-length
-of some cheese cube and the pizzas' diameter, calculate the number of pizzas
-that can be made (always rounded down). For example, given a 25x25x25cm cheese
-cube and pizzas 30cm in diameter:
+On Lilly's planet, all cheese comes in perfect cubes and is sold by size.
+(What were you expecting? This is an alien planet after all...)
+Your task is to help Lilly calculate how many pizzas they can make using any given cheese cube.
+Mozzarella cheese has a density of 0.5 grams per cubic centimeter and every pizza needs 3 grams of cheese per square centimeter.
+Given the side-length of some cheese cube and the pizzas' diameter, calculate the number of pizzas that can be made (always rounded down).
+For example, given a 25x25x25cm cheese cube and pizzas 30cm in diameter:
 
 ```lisp
 (pizzas-per-cube 25 30) ; => 3
 ```
 
-Once again, Lilly has come to the rescue with an equation calculating the number
-of pizzas (n) of some diameter (d) that can be made from a cheese cube of a
-side-length (l):
+Once again, Lilly has come to the rescue with an equation calculating the number of pizzas (n) of some diameter (d) that can be made from a cheese cube of a side-length (l):
 
 $$n = \dfrac{2l^3}{3 \pi d^2}$$
 
 ## 4. A Fair Share
 
-Finally, Lilly wants to be sure that their pizzas (each made up of 8 slices) can
-be evenly divided between their friends. Your task is to define a function
-that takes a number of pizzas and number of friends then returns `T` if the
-pizza can be evenly divided between friends and `NIL` otherwise. For example:
+Finally, Lilly wants to be sure that their pizzas (each made up of 8 slices) can be evenly divided between their friends.
+Your task is to define a function that takes a number of pizzas and number of friends then returns `T` if the pizza can be evenly divided between friends and `NIL` otherwise.
+For example:
 
 ```lisp
 ;; For splitting 3 pizzas between 4 friends

--- a/exercises/concept/pizza-pi/.docs/instructions.md
+++ b/exercises/concept/pizza-pi/.docs/instructions.md
@@ -20,7 +20,7 @@ For example, to make 4 pizzas 30cm in diameter:
 
 Helpfully, Lilly has worked out the following equation for calculating grams of dough (g) from the number of pizzas (n) and their diameters (d): 
 
-$$g = n \cdot \left(\dfrac{45 \pi d}{20} + 200\right)$$
+`g = n * (((45 * pi * d) / 20) + 200)`
 
 ## 2. A Splash of Sauce
 
@@ -35,7 +35,7 @@ For example, given Lilly has used 250ml of sauce:
 
 For this task, Lilly has prepped the following equation relating milliliters of sauce applied (s) to the pizza diameter (d): 
 
-$$d = \sqrt{\dfrac{40s}{3\pi}}$$
+`d = square-root of ((40 * s) / (3 * pi))`
 
 ## 3. Some Cheese, Please
 
@@ -52,7 +52,7 @@ For example, given a 25x25x25cm cheese cube and pizzas 30cm in diameter:
 
 Once again, Lilly has come to the rescue with an equation calculating the number of pizzas (n) of some diameter (d) that can be made from a cheese cube of a side-length (l):
 
-$$n = \dfrac{2l^3}{3 \pi d^2}$$
+`n = (2 * (l^2))/(3 * pi * (d^2))`
 
 ## 4. A Fair Share
 

--- a/exercises/concept/pizza-pi/.docs/introduction.md
+++ b/exercises/concept/pizza-pi/.docs/introduction.md
@@ -4,14 +4,11 @@ In Common Lisp, like many languages, numbers come in a few of types – two of t
 
 ## Integers
 
-Like many languages Common Lisp contains integers. These are whole numbers without a decimal point (like `-6`, `0`, `25`, `1234`,
-etc.)
+Like many languages Common Lisp contains integers. These are whole  numbers without a decimal point (like `-6`, `0`, `25`, `1234`, etc.)
 
 Common Lisp defines no limits on the magnitude of integers. Integers can be arbitrarily large (or small if negative).
 
-In general, if you are working with only whole numbers, you should prefer
-integers as they don't suffer from the same loss of precision as floating-point
-numbers do over many calculations.
+In general, if you are working with only whole numbers, you should  prefer integers as they don't suffer from the same loss of precision as floating-point numbers do over many calculations.
 
 ## Floating Point Numbers
 
@@ -19,9 +16,7 @@ Also like many languages, Common Lisp contains floating point numbers. These are
 
 ## Arithmetic
 
-Common Lisp uses the standard arithmetic operators for most operations but is
-somewhat unique in using a "prefix-notation" as opposed to the more familiar
-"infix-notion". More visually:
+Common Lisp uses the standard arithmetic operators for most operations but is somewhat unique in using a "prefix-notation" as opposed to the more familiar "infix-notion". More visually:
 
 ```lisp
 ;; Infix-notation (non-lisp languages)
@@ -30,13 +25,8 @@ somewhat unique in using a "prefix-notation" as opposed to the more familiar
 (+ 1 2 3 4 5) ; => 15
 ```
 
-While prefix notion turns some operations like `2 + 2` into the somewhat
-unfamiliar `(+ 2 2)` form, it makes it much easier to operate on more than one
-number at a time.
+While prefix notion turns some operations like `2 + 2` into the somewhat unfamiliar `(+ 2 2)` form, it makes it much easier to operate on more than one number at a time.
 
 ## Comparing Numbers
 
-Finally, you may find it useful to compare different numbers using functions
-like `=` (equal), `/=` (not equal to), and `>=` (greater than or equal to). When
-these comparisons are true (as in `(= 1 1)`), they return `T` and when they
-aren't (as in `(> 0 1)`), they return `NIL`.
+Finally, you may find it useful to compare different numbers using functions like `=` (equal), `/=` (not equal to), and `>=` (greater than or equal to). When these comparisons are true (as in `(= 1 1)`), they return `T` and when they aren't (as in `(> 0 1)`), they return `NIL`.


### PR DESCRIPTION
MathJax is not currently supported so it must be removed.

This PR also contains an initial commit with all the exercise's documents being reforammted according to the style guide.

Fixes #408 