### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/.meta/example.lisp
+++ b/exercises/practice/hello-world/.meta/example.lisp
@@ -1,5 +1,5 @@
 (defpackage #:hello-world
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:hello))
 
 (in-package #:hello-world)

--- a/exercises/practice/hello-world/hello-world.lisp
+++ b/exercises/practice/hello-world/hello-world.lisp
@@ -1,6 +1,7 @@
 (defpackage #:hello-world
-  (:use #:cl)
+  (:use #:common-lisp)
   (:export #:hello))
+
 (in-package #:hello-world)
 
-(defun hello () "Put your greeting here.")
+(defun hello () "Goodbye, Mars!")

--- a/exercises/practice/hello-world/hello-world.lisp
+++ b/exercises/practice/hello-world/hello-world.lisp
@@ -1,5 +1,5 @@
 (defpackage #:hello-world
-  (:use #:common-lisp)
+  (:use #:cl)
   (:export #:hello))
 
 (in-package #:hello-world)


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46