### PR TITLE
Catch a couple of lingering `:common-lisp`s

### DIFF
--- a/docs/template-production.lisp
+++ b/docs/template-production.lisp
@@ -1,6 +1,6 @@
 (in-package #:cl-user)
 (defpackage #:exercise
-  (:use #:common-lisp)
+  (:use #:cl)
   (:shadow #:list)
   (:export #:function-under-test))
 

--- a/docs/template-test.lisp
+++ b/docs/template-test.lisp
@@ -2,7 +2,7 @@
 #-xlisp-test (load "exercise")
 
 (defpackage #:exercise-test
-  (:use #:common-lisp #:lisp-unit))
+  (:use #:cl #:lisp-unit))
 
 (in-package #:exercise-test)
 

--- a/exercises/practice/binary/binary.lisp
+++ b/exercises/practice/binary/binary.lisp
@@ -1,5 +1,5 @@
 (defpackage #:binary
-  (:use :common-lisp)
+  (:use :cl)
   (:export :to-decimal))
 
 (in-package :binary)


### PR DESCRIPTION
This actually brings up another issue... It seems we are inconsistent about using interned vs uninterned symbols for imports and exports.

For example, here is one file header (`exercises/practice/binary/binary.lisp`) with an interesting mix of interned and uninterned symbols:

```lisp
(defpackage #:binary
  (:use :cl)
  (:export :to-decimal))

(in-package :binary)
```

And here is another with all uninterned symbols (`docs/template-production.lisp`):

```lisp
(in-package #:cl-user)
(defpackage #:exercise
  (:use #:cl)
  (:shadow #:list)
  (:export #:function-under-test))

(in-package #:exercise)
```

I'll admit that I've probably created a lot of the interned files, but I now understand that the uninterned `#:cl~ method is preferred to avoid cluttering package namespaces. Let me know @verdammelt if you'd like me to convert everything to being uninterned!