### PR TITLE
Add instructions on using print to debug test runs.

### DIFF
--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -1,0 +1,8 @@
+# Debug
+
+To help with debugging, you can use [`print` or similar functions](http://www.lispworks.com/documentation/HyperSpec/Body/f_wr_pr.htm) to write to standard output which will be visible in the test output.
+
+For example `(print "hello there")` in your code will cause it to be visible in the test runs.
+
+One "trick" if you have several things to print out is to collect them together in a list and then print that: `(print (list :this "that" 'the-other))`.
+

--- a/exercises/shared/.docs/debug.md
+++ b/exercises/shared/.docs/debug.md
@@ -2,7 +2,7 @@
 
 To help with debugging, you can use [`print` or similar functions](http://www.lispworks.com/documentation/HyperSpec/Body/f_wr_pr.htm) to write to standard output which will be visible in the test output.
 
-For example `(print "hello there")` in your code will cause it to be visible in the test runs.
+For example adding `(print "hello there")` into the function you are writing will cause it to be visible in the test runs (given that the test executes that function).
 
-One "trick" if you have several things to print out is to collect them together in a list and then print that: `(print (list :this "that" 'the-other))`.
+One "trick": if you have several things to print out is to collect them together in a list and then print that: `(print (list :this "that" 'the-other))`.
 


### PR DESCRIPTION
Just a quick document explaining how to use `print` to do some debugging for test runs in the browser.

Relates to #355.