### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -829,32 +829,32 @@
   ],
   "key_features": [
     {
-      "icon": "feature-interactive",
+      "icon": "interactive",
       "title": "Interactive",
       "content": "Common Lisp has a full featured REPL, development can happen as a 'conversation' with the system."
     },
     {
-      "icon": "feature-inspectable",
+      "icon": "documentation",
       "title": "Inspectible",
       "content": "Common Lisp is fully inspectable with built-in functions for exploring every part of the language."
     },
     {
-      "icon": "feature-homoiconicity",
+      "icon": "homoiconic",
       "title": "Homoiconicity",
       "content": "Code has the same structure as data, allowing for powerful macros: code that writes code."
     },
     {
-      "icon": "feature-extensible",
+      "icon": "extensible",
       "title": "Extensible",
       "content": "Generic functions, reader-macros, and flexible namespacing allow for the extension of the language"
     },
     {
-      "icon": "feature-standardized",
+      "icon": "stable",
       "title": "Standardized",
       "content": "The language is very stable, with multiple implementations to match your needs – JVM, embedded, etc."
     },
     {
-      "icon": "feature-multiparadigm",
+      "icon": "multi-paradigm",
       "title": "Multiparadigm",
       "content": "Whether you prefer a functional style or something more object-oriented, Lisp adapts to your needs."
     }


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![interactive](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interactive.svg) Interactive
Common Lisp has a full featured REPL, development can happen as a 'conversation' with the system.

![documentation](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/documentation.svg) Inspectible
Common Lisp is fully inspectable with built-in functions for exploring every part of the language.

![homoiconic](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/homoiconic.svg) Homoiconicity
Code has the same structure as data, allowing for powerful macros: code that writes code.

![extensible](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/extensible.svg) Extensible
Generic functions, reader-macros, and flexible namespacing allow for the extension of the language

![stable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/stable.svg) Standardized
The language is very stable, with multiple implementations to match your needs – JVM, embedded, etc.

![multi-paradigm](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/multi-paradigm.svg) Multiparadigm
Whether you prefer a functional style or something more object-oriented, Lisp adapts to your needs.
