### PR TITLE
Adding test-op to config-checker system

### DIFF
--- a/.github/workflows/config-checker.yml
+++ b/.github/workflows/config-checker.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Run Config Check
         run: |
           ${HOME}/ql-sbcl --eval "(ql:quickload \"config-checker\")" \
-                          --eval "(config-checker:ci-check-config)"  \
+                          --eval "(asdf:test-system \"config-checker\")" \
                           --quit

--- a/src/config-checker.asd
+++ b/src/config-checker.asd
@@ -15,4 +15,8 @@
                (:module "checkers"
                 :components ((:file "each-concept-directory-is-a-concept")
                              (:file "each-concept-has-a-directory")
-                             (:file "exercise-concepts-are-in-concept-list")))))
+                             (:file "exercise-concepts-are-in-concept-list"))))
+
+  :perform (test-op (o c)
+                    (declare (ignore o c))
+                    (uiop:symbol-call :config-checker ':check-config)))

--- a/src/config-checker/main.lisp
+++ b/src/config-checker/main.lisp
@@ -9,8 +9,3 @@
     (dolist (checker *checkers*)
       (format *debug-io* "~&Running Checker: ~S~&" checker)
       (funcall checker config))))
-
-(defun ci-check-config ()
-  "Version of CHECK-CONFIG for use in CI processes. Will exit with an error code."
-  (handler-case (check-config)
-    (error () (uiop:quit -1))))


### PR DESCRIPTION
Removes need for ci function.

Now we can just `(asdf:test-system "config-checker")`

As for REPL usage - i think this will be fine with SLIME/SLY integration with ASDF it is pretty smooth.

Fixes #413.