### PR TITLE
Fix each-concept-has-a-directory checker: check for directory.

### DIFF
--- a/src/config-checker/checkers/each-concept-has-a-directory.lisp
+++ b/src/config-checker/checkers/each-concept-has-a-directory.lisp
@@ -3,7 +3,7 @@
 (defun each-concept-has-a-directory (config)
   (let* ((concepts (track-config:slugs (track-config:listed-concepts config)))
          (bad-concepts
-           (remove-if #'(lambda (c) (probe-file (merge-pathnames c "./concepts/"))) concepts)))
+           (remove-if #'(lambda (c) (uiop:directory-exists-p (merge-pathnames c "./concepts/"))) concepts)))
     (when bad-concepts
       (dolist (c bad-concepts)
         (format *error-output* "Concept: ~S does not have a directory~&" c))


### PR DESCRIPTION
Was passing if there was just a file with the correct name in the
concepts directory.