### PR TITLE
Minor fixes in Leslie's list's instructions and template solution

### DIFF
--- a/exercises/concept/leslies-lists/.docs/instructions.md
+++ b/exercises/concept/leslies-lists/.docs/instructions.md
@@ -64,5 +64,5 @@ Leslie realized they accidentally made two shopping lists not one! Write a funct
 Leslie is starting to get worried that this shopping trip is going to take quite a while. Just how many things are on this list? Write a function `just-how-long` to tell them just how long their list is.
 
 ```lisp
-(list-append '(bread milk butter salt)) ; => 4
+(just-how-long '(bread milk butter salt)) ; => 4
 ```

--- a/exercises/concept/leslies-lists/leslies-lists.lisp
+++ b/exercises/concept/leslies-lists/leslies-lists.lisp
@@ -34,4 +34,4 @@
 
 (defun list-append (list1 list2))
 
-(defun just-how-long ())
+(defun just-how-long (list))


### PR DESCRIPTION
Add missing paramater name to function template and fix using wrong function in the instructions.

Also, in the _Bigger lists out of smaller lists_ section, it says:
> Leslie realized they accidentally made two shopping lists not one! Write a function called list-append which adds all the items from the second list provided to the end of the first list.

I assume the intended solution would be to use `append` and not `nconc`, but that would not _add the items to the list_ but instead return a new list.