### PR TITLE
Add missing "no" at conditional concept

### DIFF
--- a/concepts/conditionals/about.md
+++ b/concepts/conditionals/about.md
@@ -16,6 +16,8 @@ As an example:
 
 The conditionals `when` and `unless` evaluate some code only when the provided test is true or false respectively – evaluating to `nil` otherwise.
 
+The section after the test expression may be more than one expression.
+
 ```lisp
 (when (= 2 2) "All is well")      ; => "All is well"
 (unless (= 2 2) "Time to panic!") ; => NIL
@@ -28,6 +30,8 @@ The `if` conditional evaluates the first expression of the body when the test is
 ```lisp
 (if (= 2 2) 'how-honest 'you-liar) ; => HOW-HONEST
 ```
+
+Note that both the then and else clauses can only be a single expression.
 
 ## Many-Branch Conditionals
 
@@ -44,6 +48,9 @@ If all of the tests evaluate to false, then `nil` is returned.
 ; => QUITE-TRUE
 ```
 
+Note that there is no limit to the number of expressions after the test expression. 
+
+
 If you just want to test one value against a number of branches, you can use the cleaner `case` expression.
 If none of the cases match, `nil` is returned.
 Both `t` and `otherwise` can be used as catch-all cases:
@@ -56,6 +63,8 @@ Both `t` and `otherwise` can be used as catch-all cases:
   (otherwise "???"))
 ; => "???"
 ```
+
+Note that like `cond` there is no limit to the number of expressions after the test expression.
 
 ## The Stealth Conditionals
 

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -30,7 +30,7 @@ Note that both the then and else clauses can only be a single expression.
 ; => QUITE-TRUE
 ```
 
-Note that there is limit to the number of expressions after the test expression.
+Note that there is no limit to the number of expressions after the test expression.
 
 - `case` provides a classic 'switch' style construct: It checks a single value against a number of branches:
 

--- a/concepts/conditionals/introduction.md
+++ b/concepts/conditionals/introduction.md
@@ -30,7 +30,7 @@ Note that both the then and else clauses can only be a single expression.
 ; => QUITE-TRUE
 ```
 
-Note that there is no limit to the number of expressions after the test expression.
+Note that there is no limit to the number of expressions after the test expression. 
 
 - `case` provides a classic 'switch' style construct: It checks a single value against a number of branches:
 

--- a/exercises/concept/pal-picker/.docs/introduction.md
+++ b/exercises/concept/pal-picker/.docs/introduction.md
@@ -37,7 +37,7 @@ Note that both the then and else clauses can only be a single expression.
 ; => QUITE-TRUE
 ```
 
-Note that there is limit to the number of expressions after the test expression.
+Note that there is no limit to the number of expressions after the test expression.
 
 - `case` provides a classic 'switch' style construct: It checks a single value against a number of branches:
 

--- a/exercises/concept/pal-picker/.docs/introduction.md
+++ b/exercises/concept/pal-picker/.docs/introduction.md
@@ -37,7 +37,7 @@ Note that both the then and else clauses can only be a single expression.
 ; => QUITE-TRUE
 ```
 
-Note that there is no limit to the number of expressions after the test expression.
+Note that there is no limit to the number of expressions after the test expression. 
 
 - `case` provides a classic 'switch' style construct: It checks a single value against a number of branches:
 


### PR DESCRIPTION
The meaning of the sentence was inverted. The sentence was repeated in two places, I changed both.

Should it be mentioned that if more than one body expression is provided the last one is the overall result (and the others are executed for side-effects)?

I also noticed that the corresponding about.md does not mention the possibility of providing more than one body expression, is this important?