### PR TITLE
Typo fix at mapping concept and nconc specification

### DIFF
--- a/concepts/mapping/about.md
+++ b/concepts/mapping/about.md
@@ -36,7 +36,7 @@ First to the entire list, then to `cdr`, then to the `cdr` of that etc.:
 `mapc` and `mapl` are like `mapcar` and `maplist` respectively but they do not collect the results and instead return the first list.
 This is used for side-effecting operations.
 
-`mapcan` and `mapcon` are like `mapcar` and `maplist` but the result is flattened by use of `nconc` which is like `append` but destructive to its first argument.
+`mapcan` and `mapcon` are like `mapcar` and `maplist` but the result is flattened by use of `nconc` which is like `append` but destructive to all but its last argument.
 
 ## Mapping on other sequences
 

--- a/concepts/mapping/about.md
+++ b/concepts/mapping/about.md
@@ -36,7 +36,7 @@ First to the entire list, then to `cdr`, then to the `cdr` of that etc.:
 `mapc` and `mapl` are like `mapcar` and `maplist` respectively but they do not collect the results and instead return the first list.
 This is used for side-effecting operations.
 
-`mapcar` and `mapcon` are like `mapcar` and `maplist` but the result is flattened by use of `nconc` which is like `append` but destructive to its first argument.
+`mapcan` and `mapcon` are like `mapcar` and `maplist` but the result is flattened by use of `nconc` which is like `append` but destructive to its first argument.
 
 ## Mapping on other sequences
 


### PR DESCRIPTION
There was a typo in the specified functions. Also I clarified that `nconc` modifies all the lists but the last one; this is not specified verbatim at the [CLHS](http://www.lispworks.com/documentation/HyperSpec/Body/f_nconc.htm) but I think is right, is it?

Feel free to make any edits.