### PR TITLE
Fixing 'twenty-third-thing' tests.

### DIFF
--- a/exercises/concept/leslies-lists/.meta/exemplar.lisp
+++ b/exercises/concept/leslies-lists/.meta/exemplar.lisp
@@ -35,7 +35,7 @@
   (third list))
 
 (defun twenty-third-thing (list)
-  (nth 23 list))
+  (nth 22 list))
 
 (defun remove-first-item (list)
   (rest list))

--- a/exercises/concept/leslies-lists/leslies-lists-test.lisp
+++ b/exercises/concept/leslies-lists/leslies-lists-test.lisp
@@ -40,7 +40,7 @@
         (is (equal 'left-handed-frobz (first-thing shopping-list)))
         (is (equal 'salt (second-thing shopping-list)))
         (is (equal 'skquargzes (third-thing shopping-list)))
-        (is (equal 'cupcakes (twenty-third-thing shopping-list)))))
+        (is (equal 'birthday-candles (twenty-third-thing shopping-list)))))
 
 
 (test removing-a-item "Leslie needs to see the list after removing the first item"


### PR DESCRIPTION
Classic off-by-one error. Twenty-third should be the 22th
item (starting at 0).

Fixes #484