### PR TITLE
Remove mutation implication at leslies-list instructions

### DIFF
--- a/exercises/concept/leslies-lists/.docs/instructions.md
+++ b/exercises/concept/leslies-lists/.docs/instructions.md
@@ -53,7 +53,7 @@ When Leslie finds the first thing on the list on the shelf then want to remove t
 
 ## 5. Bigger lists out of smaller lists
 
-Leslie realized they accidentally made two shopping lists not one! Write a function called `list-append` which adds all the items from the second list provided to the end of the first list.
+Leslie realized they accidentally made two shopping lists not one! Write a function called `list-append` which returns a list that contains the elements from the first list followed by the ones from the second list.
 
 ```lisp
 (list-append '(bread salt) '(butter milk)) ; => '(bread salt butter milk)


### PR DESCRIPTION
Removed the implication of mutation in the instructions as mentioned in #476.

I avoided phrasing the returned value as a _new list_ due to [`append`](http://www.lispworks.com/documentation/HyperSpec/Body/f_append.htm) returning its last argument directly "if there are no preceding non-empty lists".

@verdammelt, I couldn't find the `about.md` file you referred at #475, did you meant `concepts/lists/about.md`?