### PR TITLE
Extract GitHub action to perform asdf system operation.

### DIFF
--- a/.github/actions/perform-system/Dockerfile
+++ b/.github/actions/perform-system/Dockerfile
@@ -1,0 +1,6 @@
+FROM clfoundation/sbcl
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/.github/actions/perform-system/action.yml
+++ b/.github/actions/perform-system/action.yml
@@ -1,0 +1,26 @@
+name: perform-system
+description: "Perform a ASDF operation on a system"
+inputs:
+  system:
+    description: "System to operate on"
+    required: true
+
+  operation:
+    description: "Operation to perform"
+    required: false
+    default: 'make'
+
+  location:
+    description: "Directory containing the system"
+    required: false
+    default: 'src/'
+
+runs:
+  using: 'docker'
+  image: Dockerfile
+  args:
+    - ${{inputs.location}}
+    - ${{inputs.operation}}
+    - ${{inputs.system}}
+        
+    

--- a/.github/actions/perform-system/entrypoint.sh
+++ b/.github/actions/perform-system/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -ex
+
+QUICKLISP_ADD_TO_INIT_FILE=true /usr/local/bin/install-quicklisp
+
+LOCATION=\"$1\"
+OPERATION=$2
+SYSTEM=\"$3\"
+
+/usr/local/bin/sbcl \
+    --noinform --non-interactive \
+    --eval "(push (merge-pathnames $LOCATION) asdf:*central-registry*)" \
+    --eval "(ql:quickload $SYSTEM)" \
+    --eval "(asdf:${OPERATION} $SYSTEM)"

--- a/.github/workflows/config-checker.yml
+++ b/.github/workflows/config-checker.yml
@@ -13,17 +13,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      - name: Install & Setup QuickLisp
-        run: |
-          QUICKLISP_ADD_TO_INIT_FILE=true /usr/local/bin/install-quicklisp
-          echo '(push (merge-pathnames "src/") asdf:*central-registry*)' >> ~/.sbclrc
-
-      - name: SBCL Version
-        run: (format t "~A-~A" (lisp-implementation-type) (lisp-implementation-version))
-        shell: sbcl --noinform --non-interactive --load {0}
-
-      - name: Run Config Check
-        run: |
-          (ql:quickload "config-checker")
-          (asdf:test-system "config-checker")
-        shell: sbcl --noinform --non-interactive --load {0}
+      - name: Check Config
+        uses: ./.github/actions/perform-system
+        with:
+          system: config-checker
+          operation: test-system

--- a/.github/workflows/test-exercises.yml
+++ b/.github/workflows/test-exercises.yml
@@ -13,17 +13,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
-      - name: Install & Setup QuickLisp
-        run: |
-          QUICKLISP_ADD_TO_INIT_FILE=true /usr/local/bin/install-quicklisp
-          echo '(push (merge-pathnames "src/") asdf:*central-registry*)' >> ~/.sbclrc
-
-      - name: SBCL Version
-        run: (format t "~A-~A" (lisp-implementation-type) (lisp-implementation-version))
-        shell: sbcl --noinform --non-interactive --load {0}
-
       - name: Run Tests
-        run: |
-          (ql:quickload "test-exercises")
-          (asdf:test-system "test-exercises")
-        shell: sbcl --noinform --non-interactive --load {0}
+        uses: ./.github/actions/perform-system
+        with:
+          system: test-exercises
+          operation: test-system


### PR DESCRIPTION
As a continuation of #502 this PR extracts a common GitHub action to run `ASDF:$OPERATION` on a system.

For example the config-checker and test-exercise CI workflows have been updated to look like this:

``` yaml
      - name: Run Tests
        uses: ./.github/actions/perform-system
        with:
          system: test-exercises
          operation: test-system
```

(with the system name obviously changed for config-checker).

The implementation of the action is perhaps clunky but I'm just learning - we can make it better as more is learnt about GitHub Actions.