### PR TITLE
Correcting use of uninterned keyword for package.

### DIFF
--- a/exercises/practice/acronym/.meta/example.lisp
+++ b/exercises/practice/acronym/.meta/example.lisp
@@ -1,9 +1,9 @@
-(in-package #:cl-user)
-(defpackage #:acronym
-  (:use #:cl)
-  (:export #:acronym))
+(in-package :cl-user)
+(defpackage :acronym
+  (:use :cl)
+  (:export :acronym))
 
-(in-package #:acronym)
+(in-package :acronym)
 
 (defun acronym (str)
   (labels ((recur (st ls)

--- a/exercises/practice/all-your-base/.meta/example.lisp
+++ b/exercises/practice/all-your-base/.meta/example.lisp
@@ -1,9 +1,9 @@
-(in-package #:cl-user)
-(defpackage #:all-your-base
-  (:use #:common-lisp)
-  (:export #:rebase))
+(in-package :cl-user)
+(defpackage :all-your-base
+  (:use :common-lisp)
+  (:export :rebase))
 
-(in-package #:all-your-base)
+(in-package :all-your-base)
 
 (defun rebase (list-digits in-base out-base)
   (when (and (< 1 in-base)

--- a/exercises/practice/allergies/.meta/example.lisp
+++ b/exercises/practice/allergies/.meta/example.lisp
@@ -1,9 +1,9 @@
-(defpackage #:allergies
-  (:use #:common-lisp)
-  (:shadow #:list)
-  (:export #:allergic-to-p #:list))
+(defpackage :allergies
+  (:use :common-lisp)
+  (:shadow :list)
+  (:export :allergic-to-p :list))
 
-(in-package #:allergies)
+(in-package :allergies)
 
 (defparameter *allergens-scores*
   '(("eggs" 1)

--- a/exercises/practice/anagram/.meta/example.lisp
+++ b/exercises/practice/anagram/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:anagram
-  (:use #:common-lisp)
-  (:export #:anagrams-for))
+(defpackage :anagram
+  (:use :common-lisp)
+  (:export :anagrams-for))
 
-(in-package #:anagram)
+(in-package :anagram)
 
 (defun anagram-equal (a b)
   (and

--- a/exercises/practice/armstrong-numbers/.meta/example.lisp
+++ b/exercises/practice/armstrong-numbers/.meta/example.lisp
@@ -1,8 +1,8 @@
-(in-package #:cl-user)
-(defpackage #:armstrong-numbers
-  (:use #:cl)
-  (:export #:armstrong-number-p))
-(in-package #:armstrong-numbers)
+(in-package :cl-user)
+(defpackage :armstrong-numbers
+  (:use :cl)
+  (:export :armstrong-number-p))
+(in-package :armstrong-numbers)
 
 (defun number->digits (number)
   (map 'list #'digit-char-p (prin1-to-string number)))

--- a/exercises/practice/atbash-cipher/.meta/example.lisp
+++ b/exercises/practice/atbash-cipher/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:atbash-cipher
-  (:use #:common-lisp)
-  (:export #:encode))
+(defpackage :atbash-cipher
+  (:use :common-lisp)
+  (:export :encode))
 
-(in-package #:atbash-cipher)
+(in-package :atbash-cipher)
 
 (defun to-string (seq)
   (concatenate 'string seq))

--- a/exercises/practice/beer-song/.meta/example.lisp
+++ b/exercises/practice/beer-song/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:beer-song
-  (:use #:common-lisp)
-  (:export #:verse #:sing))
+(defpackage :beer-song
+  (:use :common-lisp)
+  (:export :verse :sing))
 
-(in-package #:beer-song)
+(in-package :beer-song)
 
 (defgeneric bottles (n))
 (defmethod bottles (n) (format nil "~A bottle~:P" n))

--- a/exercises/practice/binary-search/.meta/example.lisp
+++ b/exercises/practice/binary-search/.meta/example.lisp
@@ -1,9 +1,9 @@
-(in-package #:cl-user)
-(defpackage #:binary-search
-  (:use #:common-lisp)
-  (:export #:binary-find #:value-error))
+(in-package :cl-user)
+(defpackage :binary-search
+  (:use :common-lisp)
+  (:export :binary-find :value-error))
 
-(in-package #:binary-search)
+(in-package :binary-search)
 
 (defun binary-find (arr el)
   (loop

--- a/exercises/practice/binary/.meta/example.lisp
+++ b/exercises/practice/binary/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:binary
-  (:use #:common-lisp)
-  (:export #:to-decimal))
+(defpackage :binary
+  (:use :common-lisp)
+  (:export :to-decimal))
 
-(in-package #:binary)
+(in-package :binary)
 
 (defun to-decimal (string)
   (loop with digits = (remove-if #'null (map 'list #'(lambda (c) (digit-char-p c 2)) string))

--- a/exercises/practice/bob/.meta/example.lisp
+++ b/exercises/practice/bob/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:bob
-  (:use #:common-lisp)
-  (:export #:response))
+(defpackage :bob
+  (:use :common-lisp)
+  (:export :response))
 
-(in-package #:bob)
+(in-package :bob)
 
 (defun contains-alpha-chars-p (msg)
   (some #'(lambda (c) (char-not-greaterp #\a c #\z))

--- a/exercises/practice/collatz-conjecture/.meta/example.lisp
+++ b/exercises/practice/collatz-conjecture/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:collatz-conjecture
-  (:use #:common-lisp)
-  (:export #:collatz))
+(defpackage :collatz-conjecture
+  (:use :common-lisp)
+  (:export :collatz))
 
-(in-package #:collatz-conjecture)
+(in-package :collatz-conjecture)
 
 (defun collatz-helper (a n)
   (cond ((= n 1)   a)

--- a/exercises/practice/crypto-square/.meta/example.lisp
+++ b/exercises/practice/crypto-square/.meta/example.lisp
@@ -1,8 +1,8 @@
-(in-package #:cl-user)
-(defpackage #:crypto-square
-  (:use #:cl)
-  (:export #:encipher))
-(in-package #:crypto-square)
+(in-package :cl-user)
+(defpackage :crypto-square
+  (:use :cl)
+  (:export :encipher))
+(in-package :crypto-square)
 
 (defun normalize (text)
   (string-downcase (remove-if-not #'alphanumericp text)))

--- a/exercises/practice/difference-of-squares/.meta/example.lisp
+++ b/exercises/practice/difference-of-squares/.meta/example.lisp
@@ -1,10 +1,10 @@
-(defpackage #:difference-of-squares
-  (:use #:cl)
-  (:export #:sum-of-squares
-           #:square-of-sum
-           #:difference))
+(defpackage :difference-of-squares
+  (:use :cl)
+  (:export :sum-of-squares
+           :square-of-sum
+           :difference))
 
-(in-package #:difference-of-squares)
+(in-package :difference-of-squares)
 
 (defun square-of-sum (n)
   (expt (* 1/2 n (1+ n)) 2))

--- a/exercises/practice/gigasecond/.meta/example.lisp
+++ b/exercises/practice/gigasecond/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:gigasecond
-  (:use #:cl)
-  (:export #:from))
+(defpackage :gigasecond
+  (:use :cl)
+  (:export :from))
 
-(in-package #:gigasecond)
+(in-package :gigasecond)
 
 (defun from (year month day hour minute second)
   (reverse

--- a/exercises/practice/grade-school/.meta/example.lisp
+++ b/exercises/practice/grade-school/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:grade-school
-  (:use #:common-lisp)
-  (:export #:make-school #:add #:grade-roster #:grade #:sorted))
+(defpackage :grade-school
+  (:use :common-lisp)
+  (:export :make-school :add :grade-roster :grade :sorted))
 
-(in-package #:grade-school)
+(in-package :grade-school)
 
 (defclass school ()
   ((roster :accessor roster :initform (make-hash-table))))

--- a/exercises/practice/grains/.meta/example.lisp
+++ b/exercises/practice/grains/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:grains
-  (:use #:cl)
-  (:export #:square #:total))
+(defpackage :grains
+  (:use :cl)
+  (:export :square :total))
 
-(in-package #:grains)
+(in-package :grains)
 
 (defun square (n) (expt 2 (1- n)))
 

--- a/exercises/practice/hamming/.meta/example.lisp
+++ b/exercises/practice/hamming/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:hamming
-  (:use #:common-lisp)
-  (:export #:distance))
+(defpackage :hamming
+  (:use :common-lisp)
+  (:export :distance))
 
-(in-package #:hamming)
+(in-package :hamming)
 
 (defun distance (str1 str2 &key (test #'char=))
   "Number of positional differences in two equal length strings."

--- a/exercises/practice/hello-world/.meta/example.lisp
+++ b/exercises/practice/hello-world/.meta/example.lisp
@@ -1,7 +1,7 @@
-(defpackage #:hello-world
-  (:use #:cl)
-  (:export #:hello))
+(defpackage :hello-world
+  (:use :cl)
+  (:export :hello))
 
-(in-package #:hello-world)
+(in-package :hello-world)
 
 (defun hello () "Hello, World!")

--- a/exercises/practice/leap/.meta/example.lisp
+++ b/exercises/practice/leap/.meta/example.lisp
@@ -1,8 +1,8 @@
-(cl:defpackage #:leap
-  (:use #:common-lisp)
-  (:export #:leap-year-p))
+(cl:defpackage :leap
+  (:use :common-lisp)
+  (:export :leap-year-p))
 
-(in-package #:leap)
+(in-package :leap)
 
 (defun divisible-by-p (n d) (= 0 (rem n d)))
 

--- a/exercises/practice/luhn/.meta/example.lisp
+++ b/exercises/practice/luhn/.meta/example.lisp
@@ -1,9 +1,9 @@
-(in-package #:cl-user)
-(defpackage #:luhn
-  (:use #:cl)
-  (:export #:validp))
+(in-package :cl-user)
+(defpackage :luhn
+  (:use :cl)
+  (:export :validp))
 
-(in-package #:luhn)
+(in-package :luhn)
 
 (defun validp (input)
   (let ((num (remove #\Space input)))

--- a/exercises/practice/meetup/.meta/example.lisp
+++ b/exercises/practice/meetup/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:meetup
-  (:use #:common-lisp)
-  (:export #:meetup))
+(defpackage :meetup
+  (:use :common-lisp)
+  (:export :meetup))
 
-(in-package #:meetup)
+(in-package :meetup)
 
 (defun day-of-week (day month year)
   (nth 6 (multiple-value-list

--- a/exercises/practice/nucleotide-count/.meta/example.lisp
+++ b/exercises/practice/nucleotide-count/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:nucleotide-count
-  (:use #:common-lisp)
-  (:export #:dna-count #:nucleotide-counts #:invalid-nucleotide))
+(defpackage :nucleotide-count
+  (:use :common-lisp)
+  (:export :dna-count :nucleotide-counts :invalid-nucleotide))
 
-(in-package #:nucleotide-count)
+(in-package :nucleotide-count)
 
 (define-condition invalid-nucleotide (error) ())
 

--- a/exercises/practice/pascals-triangle/.meta/example.lisp
+++ b/exercises/practice/pascals-triangle/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:pascals-triangle
-  (:use #:common-lisp)
-  (:export #:rows))
+(defpackage :pascals-triangle
+  (:use :common-lisp)
+  (:export :rows))
 
-(in-package #:pascals-triangle)
+(in-package :pascals-triangle)
 
 (defun fact (n)
   (loop for i from 0 to n

--- a/exercises/practice/perfect-numbers/.meta/example.lisp
+++ b/exercises/practice/perfect-numbers/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:perfect-numbers
-  (:use #:common-lisp)
-  (:export #:classify))
+(defpackage :perfect-numbers
+  (:use :common-lisp)
+  (:export :classify))
 
-(in-package #:perfect-numbers)
+(in-package :perfect-numbers)
 
 (defun divisors (n)
   (remove-if-not (lambda (x) (= 0 (rem n x)))

--- a/exercises/practice/prime-factors/.meta/example.lisp
+++ b/exercises/practice/prime-factors/.meta/example.lisp
@@ -1,9 +1,9 @@
-(defpackage #:prime-factors
-  (:use #:cl)
-  (:export #:factors-of)
+(defpackage :prime-factors
+  (:use :cl)
+  (:export :factors-of)
   (:documentation "Generates a list of prime factors of given integer."))
 
-(in-package #:prime-factors)
+(in-package :prime-factors)
 
 (defun make-wheel-2-3-5-7 ()
   "Returns function generating prime-ish numbers."

--- a/exercises/practice/raindrops/.meta/example.lisp
+++ b/exercises/practice/raindrops/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:raindrops
-  (:use #:common-lisp)
-  (:export #:convert))
+(defpackage :raindrops
+  (:use :common-lisp)
+  (:export :convert))
 
-(in-package #:raindrops)
+(in-package :raindrops)
 
 (defparameter *raindrops*
   '((3 . "Pling")

--- a/exercises/practice/rna-transcription/.meta/example.lisp
+++ b/exercises/practice/rna-transcription/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:rna-transcription
-  (:use #:common-lisp)
-  (:export #:to-rna))
+(defpackage :rna-transcription
+  (:use :common-lisp)
+  (:export :to-rna))
 
-(in-package #:rna-transcription)
+(in-package :rna-transcription)
 
 (defun validate-strand (strand)
   (or (every #'(lambda (c) (find c "ATCGU"))

--- a/exercises/practice/robot-name/.meta/example.lisp
+++ b/exercises/practice/robot-name/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:robot-name
-  (:use #:common-lisp)
-  (:export #:build-robot #:robot-name #:reset-name #:robot))
+(defpackage :robot-name
+  (:use :common-lisp)
+  (:export :build-robot :robot-name :reset-name :robot))
 
-(in-package #:robot-name)
+(in-package :robot-name)
 
 (defun random-alpha-char ()
   (code-char (+ (char-code #\A) (random 26))))

--- a/exercises/practice/robot-simulator/.meta/example.lisp
+++ b/exercises/practice/robot-simulator/.meta/example.lisp
@@ -1,9 +1,9 @@
-(defpackage #:robot-simulator
-  (:use #:common-lisp)
-  (:export #:+north+ #:+east+ #:+south+ #:+west+ #:execute-sequence
-           #:robot #:robot-position #:robot-bearing #:make-robot))
+(defpackage :robot-simulator
+  (:use :common-lisp)
+  (:export :+north+ :+east+ :+south+ :+west+ :execute-sequence
+           :robot :robot-position :robot-bearing :make-robot))
 
-(in-package #:robot-simulator)
+(in-package :robot-simulator)
 
 (defconstant +north+ #C(0 1))
 (defconstant +east+ #C(1 0))

--- a/exercises/practice/roman-numerals/.meta/example.lisp
+++ b/exercises/practice/roman-numerals/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:roman-numerals
-  (:use #:cl)
-  (:export #:romanize))
+(defpackage :roman-numerals
+  (:use :cl)
+  (:export :romanize))
 
-(in-package #:roman-numerals)
+(in-package :roman-numerals)
 
 (defun romanize (number)
   (format nil "~@R" number))

--- a/exercises/practice/scrabble-score/.meta/example.lisp
+++ b/exercises/practice/scrabble-score/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:scrabble-score
-  (:use #:cl)
-  (:export #:score-word))
+(defpackage :scrabble-score
+  (:use :cl)
+  (:export :score-word))
 
-(in-package #:scrabble-score)
+(in-package :scrabble-score)
 
 (defparameter *letter-scores*
   '((#\A . 1) (#\B . 3) (#\C . 3) (#\D . 2) (#\E . 1) (#\F . 4)

--- a/exercises/practice/sieve/.meta/example.lisp
+++ b/exercises/practice/sieve/.meta/example.lisp
@@ -1,9 +1,9 @@
-(defpackage #:sieve
-  (:use #:cl)
-  (:export #:primes-to)
+(defpackage :sieve
+  (:use :cl)
+  (:export :primes-to)
   (:documentation "Generates a list of primes up to a given limit."))
 
-(in-package #:sieve)
+(in-package :sieve)
 
 (defun primes-to (n)
   "List primes up to `n' using sieve of Eratosthenes."

--- a/exercises/practice/space-age/.meta/example.lisp
+++ b/exercises/practice/space-age/.meta/example.lisp
@@ -1,7 +1,7 @@
-(defpackage #:space-age
-  (:use #:common-lisp))
+(defpackage :space-age
+  (:use :common-lisp))
 
-(in-package #:space-age)
+(in-package :space-age)
 
 (defvar +earth-period+ 31557600)
 

--- a/exercises/practice/strain/.meta/example.lisp
+++ b/exercises/practice/strain/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:strain
-  (:use #:common-lisp)
-  (:export #:keep #:discard))
+(defpackage :strain
+  (:use :common-lisp)
+  (:export :keep :discard))
 
-(in-package #:strain)
+(in-package :strain)
 
 (defun keep (pred seq)
   (labels

--- a/exercises/practice/sublist/.meta/example.lisp
+++ b/exercises/practice/sublist/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:sublist
-  (:use #:common-lisp)
-  (:export #:sublist))
+(defpackage :sublist
+  (:use :common-lisp)
+  (:export :sublist))
 
-(in-package #:sublist)
+(in-package :sublist)
 
 (defun is-prefix-of (xs ys)
   (cond ((null xs)                 T)

--- a/exercises/practice/trinary/.meta/example.lisp
+++ b/exercises/practice/trinary/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:trinary
-  (:use #:common-lisp)
-  (:export #:to-decimal))
+(defpackage :trinary
+  (:use :common-lisp)
+  (:export :to-decimal))
 
-(in-package #:trinary)
+(in-package :trinary)
 
 (defun to-decimal (string)
   "Return the decimal value for STRING which is in trinary. If STRING

--- a/exercises/practice/twelve-days/.meta/example.lisp
+++ b/exercises/practice/twelve-days/.meta/example.lisp
@@ -1,9 +1,9 @@
-(in-package #:cl-user)
-(defpackage #:twelve-days
-  (:use #:cl)
-  (:export #:recite))
+(in-package :cl-user)
+(defpackage :twelve-days
+  (:use :cl)
+  (:export :recite))
 
-(in-package #:twelve-days)
+(in-package :twelve-days)
 
 (defvar *gifts*
   (nreverse

--- a/exercises/practice/two-fer/.meta/example.lisp
+++ b/exercises/practice/two-fer/.meta/example.lisp
@@ -1,8 +1,8 @@
-(in-package #:cl-user)
-(defpackage #:two-fer
-  (:use #:cl)
-  (:export #:twofer))
-(in-package #:two-fer)
+(in-package :cl-user)
+(defpackage :two-fer
+  (:use :cl)
+  (:export :twofer))
+(in-package :two-fer)
 
 (defun twofer (&optional name)
   (format nil "One for ~a, one for me." (or name "you")))

--- a/exercises/practice/word-count/.meta/example.lisp
+++ b/exercises/practice/word-count/.meta/example.lisp
@@ -1,8 +1,8 @@
-(defpackage #:word-count
-  (:use #:common-lisp)
-  (:export #:count-words))
+(defpackage :word-count
+  (:use :common-lisp)
+  (:export :count-words))
 
-(in-package #:word-count)
+(in-package :word-count)
 
 (defun split-string (string)
   (labels ((split-string-iter (string result)

--- a/src/ex-maint-utils/package.lisp
+++ b/src/ex-maint-utils/package.lisp
@@ -1,4 +1,4 @@
-(defpackage #:ex-maint-utils
+(defpackage :ex-maint-utils
   (:use :cl :stubs)
   (:export :stub-concept
            :stub-concept-exercise))


### PR DESCRIPTION
For this track's code we decided to *not* use uninterned keywords
while the student-facing code was changed the non-student-facing code
was still in the old style.