### PR TITLE
Print better message when exercise package cannot be found.

### DIFF
--- a/src/test-exercises/exercises.lisp
+++ b/src/test-exercises/exercises.lisp
@@ -18,6 +18,19 @@
     (handler-bind ((style-warning #'muffle-warning))
       (load file))))
 
+(defun missing-exercise-package-error-report (condition stream)
+  (format stream
+          "Could not find package ~S (perhaps exercise slug and code do not match?)"
+          (package-error-package condition)))
+
+(define-condition missing-exercise-package-error (package-error) ()
+  (:documentation "Error to signal if exercise package (or exercise test package) cannot be found")
+  (:report missing-exercise-package-error-report))
+
 (defun find-exercise-package (exercise &key (test nil))
-  (let ((slug (symbol-name (aget :slug exercise))))
-   (find-package (string-upcase (format nil "~A~@[-TEST~]" slug test)))))
+  (let* ((slug (symbol-name (aget :slug exercise)))
+         (package-name (string-upcase (format nil "~A~@[-TEST~]" slug test)))
+         (package (find-package package-name)))
+    (if (not package)
+        (error 'missing-exercise-package-error :package package-name)
+        package)))

--- a/src/test-exercises/run.lisp
+++ b/src/test-exercises/run.lisp
@@ -7,16 +7,19 @@
 (defun %test-exercise (data)
   (let ((test-files (aget :test (aget :files data)))
         (exemplar-files (example-files data)))
-    (unwind-protect
-         (progn
-           (dolist (f (append test-files exemplar-files))
-             (load-exercise-file data f))
-           (let ((fiveam:*print-names* nil))
-             (fiveam:run (find-symbol
-                          (format nil "~A-SUITE" (symbol-name (aget :slug data)))
-                          (find-exercise-package data :test t)))))
-      (delete-package (find-exercise-package data :test t))
-      (delete-package (find-exercise-package data)))))
+    (handler-case
+     (unwind-protect
+          (progn
+            (dolist (f (append test-files exemplar-files))
+              (load-exercise-file data f))
+            (let ((fiveam:*print-names* nil))
+              (fiveam:run (find-symbol
+                           (format nil "~A-SUITE" (symbol-name (aget :slug data)))
+                           (find-exercise-package data :test t)))))
+       (delete-package (find-exercise-package data :test t))
+       (delete-package (find-exercise-package data)))
+      (package-error (c)
+        (error (format nil "PACKAGE-ERROR with package ~S" (package-error-package c)))))))
 
 (defun test-exercise (dir)
   (sb-ext:gc :full t)


### PR DESCRIPTION
What often happens is that the test slug (the directory name) does not
match the solution or test package names. When this happens the CI
runner prints a message saying it could not find package NIL which is
not very useful.

Creating a specific error here for missing exercise packages which has
a much more useful report.