### PR TITLE
Fix typos

### DIFF
--- a/exercises/concept/leslies-lists/.docs/instructions.md
+++ b/exercises/concept/leslies-lists/.docs/instructions.md
@@ -8,10 +8,10 @@ Can you help Leslie keep track of the shopping list?
 
 ## 1. Making a new list
 
-First thing is that Leslie needs to create a new empty list. A function called `empty-list` would be perfect for that.
+First thing is that Leslie needs to create a new empty list. A function called `new-list` would be perfect for that.
 
 ```lisp
-(empty-list) ; => ()
+(new-list) ; => ()
 ```
 
 Oh no... Leslie actually has a few things in mind already so they need a function that takes a three items (luckily Leslie never creates a list if they have less or more than three items) and creates a new shopping list with those things. Write a function called `list-of-things` which will take three items and makes a list of them.

--- a/exercises/concept/log-levels/.docs/instructions.md
+++ b/exercises/concept/log-levels/.docs/instructions.md
@@ -23,7 +23,7 @@ The level of the log string determines its severity.
 Define a function `log-severity` which will take a log string and evaluate to the correct severity.
 
 ```lisp
-(log-message "[warn]: might want to get that checked") ; => :getting-worried
+(log-severity "[warn]: might want to get that checked") ; => :getting-worried
 ```
 
 ## 3. Dealing with the vagaries of reality
@@ -31,7 +31,7 @@ Define a function `log-severity` which will take a log string and evaluate to th
 Unfortunately sometimes the log strings are not always formatted correctly. Specifically the log level may be not all lower case as specified above. Modify `log-severity` to handle this.
 
 ```lisp
-(log-message "[WaRn] string case system failing") ; => :getting-worried
+(log-severity "[WaRn] string case system failing") ; => :getting-worried
 ```
 
 ## 4. Reformatting the log message according to log severity


### PR DESCRIPTION
Hey there. I found some inconsistencies between function names in the docs vs. those used in the source files.