### PR TITLE
functions: Fixed the example function name

### DIFF
--- a/concepts/functions/introduction.md
+++ b/concepts/functions/introduction.md
@@ -9,7 +9,7 @@ Functions may have zero or more parameters.
 ```lisp
 (defun no-args () (+ 1 1))
 
-(defun add-one (x) (+1 x))
+(defun add-one (x) (1+ x))
 
 (defun add-nums (x y) (+ x y))
 ```


### PR DESCRIPTION
Replaces the `+1` with the `1+` function call