### PR TITLE
Fix rounding in tests.

### DIFF
--- a/exercises/practice/space-age/space-age-test.lisp
+++ b/exercises/practice/space-age/space-age-test.lisp
@@ -16,7 +16,7 @@
 (def-suite* space-age-suite)
 
 (defun rounds-to (expected actual)
-  (flet ((to-2-places (n) (/ (fround (* 100 n)))))
+  (flet ((to-2-places (n) (/ (fround (* 100 n)) 100.0)))
     (is (= (to-2-places expected) (to-2-places actual)))))
 
 (test age-in-earth-years


### PR DESCRIPTION
The tests intended to multiply the number by 100, round then divide by
10 to get 2 decimal places - but the code divided but did not specify
'100' so it was taking the reciprocal. The error message thus was
confusing.

It may not fix the reported issue #519 but I think it does address the
issue in that the error will no longer by misleading and the student
can hopefully see what they may or may not be doing wrong.

Fixes #519