### PR TITLE
Remove arithmetic from leslie-list prerequisites

### DIFF
--- a/config.json
+++ b/config.json
@@ -62,7 +62,7 @@
         "name": "Leslie's Lengthy Lists",
         "uuid": "fd1aaa1a-f3c0-419e-a713-761c5147a5e1",
         "concepts": ["lists"],
-        "prerequisites": ["cons", "symbols", "arithmetic"],
+        "prerequisites": ["cons", "symbols"],
         "status": "beta"
       },
       {


### PR DESCRIPTION
Doesn't seem to be necessary and removing it allows 'list' concept to
follow directly from 'cons'.

Fixes #523