### PR TITLE
Specify that Lenny's favorite food is not null

### DIFF
--- a/exercises/concept/socks-and-sexprs/socks-and-sexprs-test.lisp
+++ b/exercises/concept/socks-and-sexprs/socks-and-sexprs-test.lisp
@@ -16,8 +16,9 @@
 (def-suite socks-and-sexprs-suite)
 (in-suite socks-and-sexprs-suite)
 
-(test symbols "Lenny's favorite food is a symbol"
+(test symbols "Lenny's favorite food is a non-null symbol"
   (is-true (symbolp (lennys-favorite-food)))
+  (is-false (null (lennys-favorite-food)))
   (is-false (keywordp (lennys-favorite-food))))
 
 (test keywords "Lenny's secret keyword is a keyword"


### PR DESCRIPTION
The original test for `symbolp` and not `keywordp` passed with no
action, because the empty function body returned nil, and `(symbolp
nil)` is true.

Require a non-nil symbol response for `(lennys-favorite-food)`.

Fixes #469 