### PR TITLE
Standardizing on lispwork links for Hyperspec.

### DIFF
--- a/concepts/arithmetic/links.json
+++ b/concepts/arithmetic/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://l1sp.org/cl/12.1.1",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/12_aa.htm",
     "description": "All numerical operations in Lisp"
   }
 ]

--- a/concepts/arrays/links.json
+++ b/concepts/arrays/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://l1sp.org/cl/13.1.1",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/13_aa.htm",
     "description": "Introduction to arrays from the specification"
   }
 ]

--- a/concepts/characters/links.json
+++ b/concepts/characters/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://l1sp.org/cl/13.1.1",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/13_aa.htm",
     "description": "Introduction to characters from the specification"
   }
 ]

--- a/concepts/comments/links.json
+++ b/concepts/comments/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://l1sp.org/cl/2.4.4.2",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/02_ddb.htm",
     "description": "Hyperspec reference regarding commenting conventions"
   }
 ]

--- a/concepts/cons/about.md
+++ b/concepts/cons/about.md
@@ -28,7 +28,7 @@ The parts of a cons may be accessed with the functions [`car`][hyper-car] and [`
 ```
 
 [history]: https://en.wikipedia.org/wiki/CAR_and_CDR#Etymology
-[hyper-car]: http://l1sp.org/cl/car
-[hyper-cdr]: http://l1sp.org/cl/cdr
-[hyper-cons]: http://l1sp.org/cl/cons
-[hyper-conses]: http://l1sp.org/cl/14
+[hyper-car]: http://www.lispworks.com/documentation/HyperSpec/Body/f_car_c.htm
+[hyper-cdr]: http://www.lispworks.com/documentation/HyperSpec/Body/f_car_c.htm
+[hyper-cons]: http://www.lispworks.com/documentation/HyperSpec/Body/f_cons.htm
+[hyper-conses]: http://www.lispworks.com/documentation/HyperSpec/Body/14_.htm

--- a/concepts/cons/links.json
+++ b/concepts/cons/links.json
@@ -1,18 +1,18 @@
 [
   {
-    "url": "http://l1sp.org/cl/14",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/14_.htm",
     "description": "Hyperspec Chapter on Conses"
   },
   {
-    "url": "http://l1sp.org/cl/cons",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/f_cons.htm",
     "description": "Hyperspec reference for `cons`"
   },
   {
-    "url": "http://l1sp.org/cl/car",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/f_car_c.htm",
     "description": "Hyperpsec reference for `car`"
   },
   {
-    "url": "http://l1sp.org/cl/cdr",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/f_car_c.htm",
     "description": "Hyperspec reference for `cdr`"
   },
   {
@@ -24,7 +24,7 @@
     "description": "Practical Common Lisp chapter on lists and conses."
   },
   {
-    "url": "http://l1sp.org/cl/14.1.2",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/14_ab.htm",
     "description": "Hyperspec reference on conses as lists."
   }
 ]

--- a/concepts/functions/links.json
+++ b/concepts/functions/links.json
@@ -8,7 +8,7 @@
     "description": "Practical Common Lisp on Functions"
   },
   {
-    "url": "http://l1sp.org/cl/defun",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/m_defun.htm",
     "description": "Hyperspec page on defun"
   }
 ]

--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -25,5 +25,5 @@ You can call `append` with any number of lists, including 1 or 0:
 
 As an alternative to `append` there is `nconc` which has the same result but has the side-effect of modifying the lists. You should be careful when using `nconc` as it may have surprising effects.
 
-[hyper-cons-as-list]: http://l1sp.org/cl/14.1.2
-[hyper-print-circle]: http://l1sp.org/cl/*print-circle*
+[hyper-cons-as-list]: http://www.lispworks.com/documentation/HyperSpec/Body/14_ab.htm
+[hyper-print-circle]: http://www.lispworks.com/documentation/HyperSpec/Body/v_pr_cir.htm

--- a/concepts/lists/links.json
+++ b/concepts/lists/links.json
@@ -8,7 +8,7 @@
     "description": "Practical Common Lisp chapter on lists and conses."
   },
   {
-    "url": "http://l1sp.org/cl/14.1.2",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/14_ab.htm",
     "description": "Hyperspec reference on conses as lists."
   }
 ]

--- a/concepts/vectors/links.json
+++ b/concepts/vectors/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://l1sp.org/cl/13.1.1",
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/13_aa.htm",
     "description": "Introduction to arrays from the specification"
   }
 ]

--- a/exercises/concept/lillys-lasagna-leftovers/.meta/design.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.meta/design.md
@@ -46,7 +46,7 @@ The concept file for `named-parameters` can (and perhaps should) mention `&allow
 
 - [Practical Common
   Lisp](http://www.gigamonkeys.com/book/functions.html)
-- [Common Lisp Hyperspec](http://clhs.lisp.se/Body/m_defun.htm)
+- [Common Lisp Hyperspec](http://www.lispworks.com/documentation/HyperSpec/Body/m_defun.htm)
 
 ### Hints
 

--- a/exercises/concept/lillys-lasagna/.meta/design.md
+++ b/exercises/concept/lillys-lasagna/.meta/design.md
@@ -40,7 +40,7 @@ This exercise should focus on teaching `defun` The student should be comfortable
 
 - [Practical Common
   Lisp](http://www.gigamonkeys.com/book/functions.html)
-- [Common Lisp Hyperspec](http://clhs.lisp.se/Body/m_defun.htm)
+- [Common Lisp Hyperspec](http://www.lispworks.com/documentation/HyperSpec/Body/m_defun.htm)
 
 ### Hints
 

--- a/exercises/concept/pal-picker/.docs/hints.md
+++ b/exercises/concept/pal-picker/.docs/hints.md
@@ -19,7 +19,7 @@
 
 - This task requires a multi-branch conditional
 - It may be worth looking into the order in which branches of [this
-  expression](http://l1sp.org/cl/cond) are evaluated.
+  expression](http://www.lispworks.com/documentation/HyperSpec/Body/m_cond.htm) are evaluated.
 
 ## 3. And Now, We Feast
 

--- a/exercises/concept/pizza-pi/.docs/hints.md
+++ b/exercises/concept/pizza-pi/.docs/hints.md
@@ -3,25 +3,25 @@
 ## General
 
 - It might be useful to have a list of all of the numeric operations in Lisp.
-– you can find a [full list here](http://l1sp.org/cl/12.1.1)
+– you can find a [full list here](http://www.lispworks.com/documentation/HyperSpec/Body/12_aa.htm)
 
 ## 1. A Dough Ratio
 
-- Common Lisp has [a built-in constant](http://l1sp.org/cl/pi) for π (pi) 
+- Common Lisp has [a built-in constant](http://www.lispworks.com/documentation/HyperSpec/Body/v_pi.htm) for π (pi) 
 - When it comes to rounding, the CL spec provides [a smattering of
-  functions](http://l1sp.org/cl/floor)
+  functions](http://www.lispworks.com/documentation/HyperSpec/Body/f_floorc.htm)
 
 ## 2. A Splash of Sauce
 
-- There is [a built-in operator](http://l1sp.org/cl/sqrt) that might help you take the square-root of a number
+- There is [a built-in operator](http://www.lispworks.com/documentation/HyperSpec/Body/f_sqrt_.htm) that might help you take the square-root of a number
 
 ## 3. Some Cheese, Please
 
-- For squaring or cubing numbers, there is a [built-in exponentiation function](http://l1sp.org/cl/expt)
-- You might want to take a look at [this page of rounding   operations](http://l1sp.org/cl/floor) and check out some of the alternatives to `round`.
+- For squaring or cubing numbers, there is a [built-in exponentiation function](http://www.lispworks.com/documentation/HyperSpec/Body/f_exp_e.htm)
+- You might want to take a look at [this page of rounding   operations](http://www.lispworks.com/documentation/HyperSpec/Body/f_floorc.htm) and check out some of the alternatives to `round`.
 
 ## 4. A Fair Share
 
 - This part requires using a function you may not have come across before, the [modulo
 function](https://en.wikipedia.org/wiki/Modulo_operation) (`mod`). This function gives you the remainder of the division between two numbers.
-- For comparing the result of `mod` to another number, [this page of comparison operators](http://l1sp.org/cl/=).
+- For comparing the result of `mod` to another number, [this page of comparison operators](http://www.lispworks.com/documentation/HyperSpec/Body/f_eq_sle.htm).

--- a/exercises/concept/socks-and-sexprs/.docs/hints.md
+++ b/exercises/concept/socks-and-sexprs/.docs/hints.md
@@ -23,5 +23,5 @@
 - A couple options might have more intuitive names than you'd expect!
 
 [so-quoting]: https://stackoverflow.com/questions/134887/when-to-use-or-quote-in-lisp
-[clhs-keywordp]: http://clhs.lisp.se/Body/f_kwdp.htm#keywordp
-[clhs-conses]: http://clhs.lisp.se/Body/c_conses.htm
+[clhs-keywordp]: http://www.lispworks.com/documentation/HyperSpec/Body/f_kwdp.htm#keywordp
+[clhs-conses]: http://www.lispworks.com/documentation/HyperSpec/Body/c_conses.htm


### PR DESCRIPTION
The track had been using a mixture of `l1sp.org`, `clhs.lisp.se` and `lispworks` links to the HyperSpec. This PR standardizes on `lispworks` which is the owner of the copyright of the document.

Fixes #441