### PR TITLE
ETL result should be in all lowercase.

### DIFF
--- a/exercises/practice/etl/.meta/example.lisp
+++ b/exercises/practice/etl/.meta/example.lisp
@@ -14,7 +14,7 @@
          (loop
             for v in (second kv)
             with k = (first kv)
-            do (setf (gethash v h) k)
+            do (setf (gethash (char-downcase v) h) k)
             finally (return h)))
      old-kvs
      :initial-value (make-hash-table :test (hash-table-test data)))))

--- a/exercises/practice/etl/etl-test.lisp
+++ b/exercises/practice/etl/etl-test.lisp
@@ -22,25 +22,25 @@
           :initial-value (make-hash-table)))
 
 (test single-letter
-  (is (equalp (make-hash '((#\A . 1)))
+  (is (equalp (make-hash '((#\a . 1)))
               (etl:transform (make-hash '((1 . (#\A))))))))
 
 (test single-score-with-multiple-letters
-  (is (equalp (make-hash '((#\A . 1) (#\E . 1) (#\I . 1) (#\O . 1) (#\U . 1)))
+  (is (equalp (make-hash '((#\a . 1) (#\e . 1) (#\i . 1) (#\o . 1) (#\u . 1)))
               (etl:transform (make-hash '((1 . (#\A #\E #\I #\O #\U))))))))
 
 (test multiple-scores-with-multiple-letters
-  (is (equalp (make-hash '((#\A . 1) (#\D . 2) (#\E . 1) (#\G . 2)))
+  (is (equalp (make-hash '((#\a . 1) (#\d . 2) (#\e . 1) (#\g . 2)))
               (etl:transform (make-hash '((1 . (#\A #\E)) (2 . (#\D #\G))))))))
 
 (test multiple-scores-with-differing-numbers-of-letters
   (is (equalp (make-hash
-               '((#\A . 1) (#\B . 3) (#\C . 3) (#\D . 2) (#\E . 1)
-                 (#\F . 4) (#\G . 2) (#\H . 4) (#\I . 1) (#\J . 8)
-                 (#\K . 5) (#\L . 1) (#\M . 3) (#\N . 1) (#\O . 1)
-                 (#\P . 3) (#\Q . 10) (#\R . 1) (#\S . 1) (#\T . 1)
-                 (#\U . 1) (#\V . 4) (#\W . 4) (#\X . 8) (#\Y . 4)
-                 (#\Z . 10)))
+               '((#\a . 1) (#\b . 3) (#\c . 3) (#\d . 2) (#\e . 1)
+                 (#\f . 4) (#\g . 2) (#\h . 4) (#\i . 1) (#\j . 8)
+                 (#\k . 5) (#\l . 1) (#\m . 3) (#\n . 1) (#\o . 1)
+                 (#\p . 3) (#\q . 10) (#\r . 1) (#\s . 1) (#\t . 1)
+                 (#\u . 1) (#\v . 4) (#\w . 4) (#\x . 8) (#\y . 4)
+                 (#\z . 10)))
               (etl:transform (make-hash
                               '((1 . (#\A #\E #\I #\O #\U #\L #\N #\R #\S #\T))
                                 (2 . (#\D #\G))


### PR DESCRIPTION
Pointed out in #539.

Took the time to ensure that the exercise is up to date with current problem-specifications and it is other than the expected outputs.

Fixes #539.