### PR TITLE
Fixed typo

### DIFF
--- a/concepts/optional-parameters/introduction.md
+++ b/concepts/optional-parameters/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-In Common Lisp a function can have some arguments are are optional.
+In Common Lisp a function can have some arguments that are optional.
 These are designated in the lambda list by `&optional` lambda list keyword.
 A parameter will be bound to the value `nil` if it is not specified.
 If there are several optional parameters they are bound in order.

--- a/exercises/concept/lillys-lasagna-leftovers/.docs/introduction.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.docs/introduction.md
@@ -14,7 +14,7 @@ Lambda lists are also used in other constructs which will be discussed later suc
 
 ## Optional Parameters
 
-In Common Lisp a function can have some arguments are are optional.
+In Common Lisp a function can have some arguments that are optional.
 These are designated in the lambda list by `&optional` lambda list keyword.
 A parameter will be bound to the value `nil` if it is not specified.
 If there are several optional parameters they are bound in order.


### PR DESCRIPTION
Minimal change proposed.  However, I was also toying with the idea of rewriting the sentence: 

 **'In Common Lisp a function can have some arguments that are optional.'**

as something like:

   **'In Common Lisp, it is possible for functions to take optional arguments.'**

or maybe:

   **'Common Lisp allows the user to add optional arguments to their functions.'**