### PR TITLE
Update hamming exercise

### DIFF
--- a/exercises/practice/hamming/.docs/instructions.md
+++ b/exercises/practice/hamming/.docs/instructions.md
@@ -16,9 +16,8 @@ They have 7 differences, and therefore the Hamming Distance is 7.
 
 The Hamming Distance is useful for lots of things in science, not just biology, so it's a nice phrase to be familiar with :)
 
-# Implementation notes
+## Implementation notes
 
 The Hamming distance is only defined for sequences of equal length, so
 an attempt to calculate it between sequences of different lengths should
-not work. The general handling of this situation (e.g., raising an
-exception vs returning a special value) may differ between languages.
+not work.

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
@@ -20,11 +27,35 @@ description = "long different strands"
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
 
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
 
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
 
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hamming/hamming-test.lisp
+++ b/exercises/practice/hamming/hamming-test.lisp
@@ -30,12 +30,15 @@
 (test larger-distance (is (equal 2 (hamming:distance "ACCAGGG" "ACTATGG"))))
 
 (test invalid-to-get-distance-for-different-length-strings
- (is (equal nil (hamming:distance "AGACAACAGCCAGCCGCCGGATT" "AGGCAA")))
+ (is (equal nil (hamming:distance "AATG" "AAA")))
  (is
   (equal nil
-         (hamming:distance "AGACAACAGCCAGCCGCCGGATT"
-                           "AGACATCTTTCAGCCGCCGGATTAGGCAA")))
- (is (equal nil (hamming:distance "AGG" "AGACAACAGCCAGCCGCCGGATT"))))
+         (hamming:distance "ATA"
+                           "AGTG"))))
+
+(test invalid-empty-strands
+  (is (equal nil (hamming:distance "" "G")))
+  (is (equal nil (hamming:distance "G" ""))))
 
 (defun run-tests (&optional (test-or-suite 'hamming-suite))
   "Provides human readable results of test run. Default to entire suite."


### PR DESCRIPTION
NOTE: this track chooses to have the function evaluate to `nil` for
invalid cases rather than signal an error. This allows this exercise
which is a simple reduction to be kept early on in the track.