### PR TITLE
Include sync output in created issue

### DIFF
--- a/.github/configlet-sync-issue.md
+++ b/.github/configlet-sync-issue.md
@@ -4,4 +4,10 @@ title: Out of sync practice exercises
 
 # Out of sync practice exercises
 
+This is the new text...
+
 `configlet sync --tests --docs --metadata --filepaths` found some out of sync practice exercises.
+
+```
+{{ env.SYNC_OUTPUT }}
+```

--- a/.github/configlet-sync-issue.md
+++ b/.github/configlet-sync-issue.md
@@ -2,12 +2,11 @@
 title: Out of sync practice exercises
 ---
 
-# Out of sync practice exercises
+Out of sync practice exercises have been detected:
 
-This is the new text...
+Command: `configlet sync --tests --docs --metadata --filepaths`
 
-`configlet sync --tests --docs --metadata --filepaths` found some out of sync practice exercises.
-
+Output: 
 ```
 {{ env.SYNC_OUTPUT }}
 ```

--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -16,7 +16,14 @@ jobs:
       uses: exercism/github-actions/configlet-ci@main
         
     - name: Configlet Sync
-      run: configlet sync --tests --docs --metadata --filepaths
+      id: sync
+      shell: bash {0}
+      run: |
+        echo "SYNC_OUTPUT<<EOF" >> $GITHUB_ENV
+        configlet sync --tests --docs --metadata --filepaths >> $GITHUB_ENV
+        exit_code=$?
+        echo "EOF" >> $GITHUB_ENV
+        exit $exit_code
 
     - name: Create issue
       if: ${{ failure() }}


### PR DESCRIPTION
When the configlet-sync workflow runs and detects out of sync exercises we want the exercise to include the output as it contains the information needed to fix the issue.

This PR includes the needed change to the workflow and template to do this.

To communicate the output between the syncing step and issue creation step we write the output directly to an environment variable in `$GITHUB_ENV`. We do this for two reasons: 1) it helps work around a problem with multi-line outputs (ref: https://trstringer.com/github-actions-multiline-strings/) and 2) we need an environment for the injection of values into the template.