### PR TITLE
Fix space-age rounding problem

### DIFF
--- a/exercises/practice/space-age/space-age-test.lisp
+++ b/exercises/practice/space-age/space-age-test.lisp
@@ -16,7 +16,7 @@
 (def-suite* space-age-suite)
 
 (defun rounds-to (expected actual)
-  (flet ((to-2-places (n) (coerce (/ (fround (* 100 n)) 100.0) 'double-float)))
+  (flet ((to-2-places (n) (/ (round (* 100 n)) 100.0)))
     (is (= (to-2-places expected) (to-2-places actual)))))
 
 (test age-in-earth-years


### PR DESCRIPTION
This problem only happens when the tests are run in the test runner.
The test runner uses `UIOP` to read in the forms and does so in a way
that causes it to bind `*read-default-float-format*` to
`'double-float`. This triggered a lurking bug in the space-age test
code and so the tests would fail due to different types of floats
being compared.

Replacing =fround= with =round= fixes the test code problem while
allowing the test-runner to do what it wants to do.

Fixes #572

## Summary

(Explain what this change is attempting to accomplish)


## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
