### PR TITLE
Test instructions gave wrong package for RUN-TESTS function

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -6,10 +6,10 @@ Start up your Common Lisp implementation in the directory of the exercise you ar
 
 Load the test file into your running Lisp implementation, for example, `(load "exercise-name-test")`. 
 (This will also load the solution file for you.)
-After the test file is loaded you may run the tests by evaluating `(exercise-name:run-tests)` in the REPL.
+After the test file is loaded you may run the tests by evaluating `(exercise-name-test:run-tests)` in the REPL.
 
 As you make changes to the solution you are writing use your editor's functionality to load the changes or evaluate `(load "exercise-name")` to load your solution file.
 
-Remember to evaluate `(exercise-name:run-tests)` to re-run the tests after loading your updated solution.
+Remember to evaluate `(exercise-name-test:run-tests)` to re-run the tests after loading your updated solution.
 
 


### PR DESCRIPTION
Fixes #584

## Checklist
- [X] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green