### PR TITLE
docs: Typo in expected input

### DIFF
--- a/exercises/concept/log-levels/.docs/instructions.md
+++ b/exercises/concept/log-levels/.docs/instructions.md
@@ -31,7 +31,7 @@ Define a function `log-severity` which will take a log string and evaluate to th
 Unfortunately sometimes the log strings are not always formatted correctly. Specifically the log level may be not all lower case as specified above. Modify `log-severity` to handle this.
 
 ```lisp
-(log-severity "[WaRn] string case system failing") ; => :getting-worried
+(log-severity "[WaRn]: string case system failing") ; => :getting-worried
 ```
 
 ## 4. Reformatting the log message according to log severity


### PR DESCRIPTION
## Summary

Fix a typo in the expected input of malformed log levels.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
