### PR TITLE
Create exercise matching-brackets

### DIFF
--- a/config.json
+++ b/config.json
@@ -570,6 +570,15 @@
         "practices": ["lists", "mapping", "functions"],
         "prerequisites": ["conditionals", "lists", "mapping", "arithmetic", "functions"],
         "status": "beta"
+      },
+      {
+        "slug": "matching-brackets",
+        "name": "Matching Brackets",
+        "uuid": "880223e2-2625-4753-917e-b1d82cc2a028",
+        "difficulty": 2,
+        "practices": ["reducing", "conditionals", "filtering"],
+        "prerequisites": ["reducing", "conditionals", "characters", "filtering", "functions"],
+        "status": "beta"
       }
     ],
     "foregone": ["accumulate", "bank-account"]

--- a/exercises/practice/matching-brackets/.docs/instructions.md
+++ b/exercises/practice/matching-brackets/.docs/instructions.md
@@ -1,0 +1,5 @@
+# Instructions
+
+Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
+or any combination thereof, verify that any and all pairs are matched
+and nested correctly.

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,0 +1,11 @@
+{
+   "blurb": "Make sure the brackets and braces all match.",
+   "source": "Ginna Baker",
+   "files": {
+      "test": ["matching-brackets-test.lisp"],
+      "solution": ["matching-brackets.lisp"],
+      "example": [".meta/example.lisp"]
+   },
+   "authors": ["PaulT89"],
+   "contributors": []
+}

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -7,5 +7,5 @@
       "example": [".meta/example.lisp"]
    },
    "authors": ["PaulT89"],
-   "contributors": []
+   "contributors": ["verdammelt"]
 }

--- a/exercises/practice/matching-brackets/.meta/example.lisp
+++ b/exercises/practice/matching-brackets/.meta/example.lisp
@@ -4,17 +4,14 @@
 
 (in-package :matching-brackets)
 
+(defparameter +bracket-lookup+ '((#\( . #\)) (#\{ . #\}) (#\[ . #\])))
+
+(defun eliminate-pairs (tracker bracket)
+  (let ((match (rassoc bracket +bracket-lookup+)))
+    (if (and tracker match (char= (car match) (car tracker)))
+      (cdr tracker)
+      (cons bracket tracker))))
+
 (defun pairedp (value)
   (let ((only-brackets (remove-if-not (lambda (c) (find c "{}[]()")) value)))
     (zerop (length (reduce #'eliminate-pairs only-brackets :initial-value '())))))
-
-(defun eliminate-pairs (tracker bracket)
-  (cond
-    ((not tracker) (cons bracket tracker))
-    ((matching-pair-p (car tracker) bracket) (cdr tracker))
-    (t (cons bracket tracker))))
-
-(defun matching-pair-p (left-bracket right-bracket)
-  (or (and (char= #\( left-bracket) (char= #\) right-bracket))
-      (and (char= #\{ left-bracket) (char= #\} right-bracket))
-      (and (char= #\[ left-bracket) (char= #\] right-bracket))))

--- a/exercises/practice/matching-brackets/.meta/example.lisp
+++ b/exercises/practice/matching-brackets/.meta/example.lisp
@@ -11,7 +11,10 @@
 (defun eliminate-pairs (tracker bracket)
   (cond
     ((not tracker) (cons bracket tracker))
-    ((or (and (char= #\( (car tracker)) (char= #\) bracket))
-         (and (char= #\{ (car tracker)) (char= #\} bracket))
-         (and (char= #\[ (car tracker)) (char= #\] bracket))) (cdr tracker))
+    ((matching-pair-p (car tracker) bracket) (cdr tracker))
     (t (cons bracket tracker))))
+
+(defun matching-pair-p (left-bracket right-bracket)
+  (or (and (char= #\( left-bracket) (char= #\) right-bracket))
+      (and (char= #\{ left-bracket) (char= #\} right-bracket))
+      (and (char= #\[ left-bracket) (char= #\] right-bracket))))

--- a/exercises/practice/matching-brackets/.meta/example.lisp
+++ b/exercises/practice/matching-brackets/.meta/example.lisp
@@ -11,7 +11,7 @@
 (defun eliminate-pairs (tracker bracket)
   (cond
     ((not tracker) (cons bracket tracker))
-    ((or (and (char= (car tracker) #\()) (char= bracket #\))
-         (and (char= (car tracker) #\{)) (char= bracket #\})
-         (and (char= (car tracker) #\[)) (char= bracket #\])) (cdr tracker))
+    ((or (and (char= #\( (car tracker)) (char= #\) bracket))
+         (and (char= #\{ (car tracker)) (char= #\} bracket))
+         (and (char= #\[ (car tracker)) (char= #\] bracket))) (cdr tracker))
     (t (cons bracket tracker))))

--- a/exercises/practice/matching-brackets/.meta/example.lisp
+++ b/exercises/practice/matching-brackets/.meta/example.lisp
@@ -1,0 +1,17 @@
+(defpackage :matching-brackets
+  (:use :cl)
+  (:export :pairedp))
+
+(in-package :matching-brackets)
+
+(defun pairedp (value)
+  (let ((only-brackets (remove-if-not (lambda (c) (find c "{}[]()")) value)))
+    (zerop (length (reduce #'eliminate-pairs only-brackets :initial-value '())))))
+
+(defun eliminate-pairs (tracker bracket)
+  (cond
+    ((not tracker) (cons bracket tracker))
+    ((or (and (char= (car tracker) #\()) (char= bracket #\))
+         (and (char= (car tracker) #\{)) (char= bracket #\})
+         (and (char= (car tracker) #\[)) (char= bracket #\])) (cdr tracker))
+    (t (cons bracket tracker))))

--- a/exercises/practice/matching-brackets/.meta/example.lisp
+++ b/exercises/practice/matching-brackets/.meta/example.lisp
@@ -13,5 +13,6 @@
       (cons bracket tracker))))
 
 (defun pairedp (value)
-  (let ((only-brackets (remove-if-not (lambda (c) (find c "{}[]()")) value)))
+  (let* ((bracket-list (append (mapcar #'car +bracket-lookup+) (mapcar #'cdr +bracket-lookup+)))
+         (only-brackets (remove-if-not (lambda (c) (find c bracket-list)) value)))
     (zerop (length (reduce #'eliminate-pairs only-brackets :initial-value '())))))

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,0 +1,60 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[81ec11da-38dd-442a-bcf9-3de7754609a5]
+description = paired square brackets
+
+[287f0167-ac60-4b64-8452-a0aa8f4e5238]
+description = empty string
+
+[6c3615a3-df01-4130-a731-8ef5f5d78dac]
+description = unpaired brackets
+
+[9d414171-9b98-4cac-a4e5-941039a97a77]
+description = wrong ordered brackets
+
+[f0f97c94-a149-4736-bc61-f2c5148ffb85]
+description = wrong closing bracket
+
+[754468e0-4696-4582-a30e-534d47d69756]
+description = paired with whitespace
+
+[ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
+description = partially paired brackets
+
+[3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
+description = simple nested brackets
+
+[2d137f2c-a19e-4993-9830-83967a2d4726]
+description = several paired brackets
+
+[2e1f7b56-c137-4c92-9781-958638885a44]
+description = paired and nested brackets
+
+[84f6233b-e0f7-4077-8966-8085d295c19b]
+description = unopened closing brackets
+
+[9b18c67d-7595-4982-b2c5-4cb949745d49]
+description = unpaired and nested brackets
+
+[a0205e34-c2ac-49e6-a88a-899508d7d68e]
+description = paired and wrong nested brackets
+
+[ef47c21b-bcfd-4998-844c-7ad5daad90a8]
+description = paired and incomplete brackets
+
+[a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
+description = too many closing brackets
+
+[a345a753-d889-4b7e-99ae-34ac85910d1a]
+description = early unexpected brackets
+
+[21f81d61-1608-465a-b850-baa44c5def83]
+description = early mismatched brackets
+
+[99255f93-261b-4435-a352-02bdecc9bdf2]
+description = math expression
+
+[8e357d79-f302-469a-8515-2561877256a1]
+description = complex latex expression

--- a/exercises/practice/matching-brackets/matching-brackets-test.lisp
+++ b/exercises/practice/matching-brackets/matching-brackets-test.lisp
@@ -1,0 +1,96 @@
+;; Ensures that matching-brackets.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "matching-brackets")
+  (quicklisp-client:quickload :fiveam))
+
+;; Defines the testing package with symbols from matching-brackets and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :matching-brackets-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
+
+;; Enter the testing package
+(in-package :matching-brackets-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* matching-brackets-suite)
+
+(test paired-square-brackets
+    (let ((value "[]"))
+     (is-true (matching-brackets:pairedp value))))
+
+(test empty-string
+    (let ((value ""))
+     (is-true (matching-brackets:pairedp value))))
+
+(test unpaired-brackets
+    (let ((value "[["))
+     (is-false (matching-brackets:pairedp value))))
+
+(test wrong-ordered-brackets
+    (let ((value "}{"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test wrong-closing-bracket
+    (let ((value "{]"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test paired-with-whitespace
+    (let ((value "{ }"))
+     (is-true (matching-brackets:pairedp value))))
+
+(test partially-paired-brackets
+    (let ((value "{[])"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test simple-nested-brackets
+    (let ((value "{[]}"))
+     (is-true (matching-brackets:pairedp value))))
+
+(test several-paired-brackets
+    (let ((value "{}[]"))
+     (is-true (matching-brackets:pairedp value))))
+
+(test paired-and-nested-brackets
+    (let ((value "([{}({}[])])"))
+     (is-true (matching-brackets:pairedp value))))
+
+(test unopened-closing-brackets
+    (let ((value "{[)][]}"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test unpaired-and-nested-brackets
+    (let ((value "([{])"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test paired-and-wrong-nested-brackets
+    (let ((value "[({]})"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test paired-and-incomplete-brackets
+    (let ((value "{}["))
+     (is-false (matching-brackets:pairedp value))))
+
+(test too-many-closing-brackets
+    (let ((value "[]]"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test early-unexpected-brackets
+    (let ((value ")()"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test early-mismatched-brackets
+    (let ((value "{)()"))
+     (is-false (matching-brackets:pairedp value))))
+
+(test math-expression
+    (let ((value "(((185 + 223.85) * 15) - 543)/2"))
+     (is-true (matching-brackets:pairedp value))))
+
+(test complex-latex-expression
+    (let ((value "\left(\begin{array}{cc} \frac{1}{3} & x\\ \mathrm{e}^{x} &... x^2 \end{array}\right)"))
+     (is-true (matching-brackets:pairedp value))))
+
+(defun run-tests (&optional (test-or-suite 'matching-brackets-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/matching-brackets/matching-brackets.lisp
+++ b/exercises/practice/matching-brackets/matching-brackets.lisp
@@ -1,0 +1,7 @@
+(defpackage :matching-brackets
+  (:use :cl)
+  (:export :pairedp))
+
+(in-package :matching-brackets)
+
+(defun pairedp (value))


### PR DESCRIPTION
## Summary

Used generator to create Matching Brackets practice exercise.

Difficulty = 2.  Oddly enough, Python and Rust have this as 1, and Ruby has it at 7 - it's definitely not 7, and 1 seems a little low.


## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
