### PR TITLE
Fix return value error

### DIFF
--- a/concepts/keyword-parameters/introduction.md
+++ b/concepts/keyword-parameters/introduction.md
@@ -15,7 +15,7 @@ Keyword parameters can be specified by the caller of the function in any order.
 
 (keyword-parameters)            ; => (NIL DEFAULT (:Z-WAS-NOT-SUPPLIED NIL))
 (keyword-parameters :y 5)       ; => (NIL 5 (:Z-WAS-NOT-SUPPLIED NIL))
-(keyword-parameters :z 10 :x 5) ; => (5 NIL (:Z-WAS-SUPPLIED 10))
+(keyword-parameters :z 10 :x 5) ; => (5 DEFAULT (:Z-WAS-SUPPLIED 10))
 ```
 
 Care should be taken when combining optional and keyword parameters as the keyword name and argument could be consumed by optional parameters:


### PR DESCRIPTION
Fix function without 'y' keyword return comment

## Summary

The comment for the third call to the function which indicates the supposed return value was wrong assuming that 'y' keyword didn't have a default value.


## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
