### PR TITLE
Create exercise isbn-verifier

### DIFF
--- a/config.json
+++ b/config.json
@@ -570,6 +570,15 @@
         "practices": ["lists", "mapping", "functions"],
         "prerequisites": ["conditionals", "lists", "mapping", "arithmetic", "functions"],
         "status": "beta"
+      },
+      {
+        "slug": "isbn-verifier",
+        "name": "Isbn Verifier",
+        "uuid": "d234aba4-daa2-4573-b9df-4592589f2ccf",
+        "difficulty": 5,
+        "practices": ["strings", "filtering", "mapping", "arithmetic"],
+        "prerequisites": ["strings", "filtering", "mapping", "arithmetic", "functions", "conditionals"],
+        "status": "beta"
       }
     ],
     "foregone": ["accumulate", "bank-account"]

--- a/exercises/practice/isbn-verifier/.docs/instructions.md
+++ b/exercises/practice/isbn-verifier/.docs/instructions.md
@@ -1,0 +1,42 @@
+# Instructions
+
+The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
+numbers. These normally contain dashes and look like: `3-598-21508-8`
+
+## ISBN
+
+The ISBN-10 format is 9 digits (0 to 9) plus one check character (either a digit or an X only). In the case the check character is an X, this represents the value '10'. These may be communicated with or without hyphens, and can be checked for their validity by the following formula:
+
+```text
+(d₁ * 10 + d₂ * 9 + d₃ * 8 + d₄ * 7 + d₅ * 6 + d₆ * 5 + d₇ * 4 + d₈ * 3 + d₉ * 2 + d₁₀ * 1) mod 11 == 0
+```
+
+If the result is 0, then it is a valid ISBN-10, otherwise it is invalid.
+
+## Example
+
+Let's take the ISBN-10 `3-598-21508-8`. We plug it in to the formula, and get:
+
+```text
+(3 * 10 + 5 * 9 + 9 * 8 + 8 * 7 + 2 * 6 + 1 * 5 + 5 * 4 + 0 * 3 + 8 * 2 + 8 * 1) mod 11 == 0
+```
+
+Since the result is 0, this proves that our ISBN is valid.
+
+## Task
+
+Given a string the program should check if the provided string is a valid ISBN-10.
+Putting this into place requires some thinking about preprocessing/parsing of the string prior to calculating the check digit for the ISBN.
+
+The program should be able to verify ISBN-10 both with and without separating dashes.
+
+## Caveats
+
+Converting from strings to numbers can be tricky in certain languages.
+Now, it's even trickier since the check digit of an ISBN-10 may be 'X' (representing '10'). For instance `3-598-21507-X` is a valid ISBN-10.
+
+## Bonus tasks
+
+* Generate a valid ISBN-13 from the input ISBN-10 (and maybe verify it again with a derived verifier).
+
+* Generate valid ISBN, maybe even from a given starting ISBN.

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,0 +1,13 @@
+{
+   "title": "ISBN Verifier",
+   "blurb": "Check if a given string is a valid ISBN-10 number.",
+   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
+   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation",
+   "files": {
+      "test": ["isbn-verifier-test.lisp"],
+      "solution": ["isbn-verifier.lisp"],
+      "example": [".meta/example.lisp"]
+   },
+   "authors": ["PaulT89"],
+   "contributors": []
+}

--- a/exercises/practice/isbn-verifier/.meta/example.lisp
+++ b/exercises/practice/isbn-verifier/.meta/example.lisp
@@ -11,6 +11,6 @@
   (let ((cleaned (remove-if-not #'alphanumericp isbn)))
     (when (= 10 (length cleaned)) ; Check isbn is 10 chars long
       (let ((num-list (map 'list #'char-to-num cleaned))) ; Map chars to numbers (or nil)
-        (unless (some #'null num-list) ; Return nil if any nils in num-list
-          (unless (member 10 (butlast num-list)) ; Return nil if any of the first 9 nums eql 10
-            (zerop (mod (apply #'+ (mapcar #'* num-list '(10 9 8 7 6 5 4 3 2 1))) 11))))))))
+        ; Return nil if any nils in num-list or if any of the first 9 nums eql 10
+        (unless (or (some #'null num-list) (member 10 (butlast num-list)))
+          (zerop (mod (apply #'+ (mapcar #'* num-list '(10 9 8 7 6 5 4 3 2 1))) 11)))))))

--- a/exercises/practice/isbn-verifier/.meta/example.lisp
+++ b/exercises/practice/isbn-verifier/.meta/example.lisp
@@ -1,0 +1,17 @@
+(defpackage :isbn-verifier
+  (:use :cl)
+  (:export :validp))
+
+(in-package :isbn-verifier)
+
+(defun validp (isbn)
+  (let ((cleaned (remove-if-not #'alphanumericp isbn)))
+    (when (= 10 (length cleaned)) ; Check isbn is 10 chars long
+      (let ((num-list (map 'list #'char-to-num cleaned))) ; Map chars to numbers (or nil)
+        (unless (some #'null num-list) ; Return nil if any nils in num-list
+          (unless (member 10 (butlast num-list)) ; Return nil if any of the first 9 nums eql 10
+            (setq total (apply #'+ (mapcar #'* num-list '(10 9 8 7 6 5 4 3 2 1))))
+            (zerop (mod total 11))))))))
+
+(defun char-to-num (input-char)
+  (if (char= #\X input-char) 10 (digit-char-p input-char)))

--- a/exercises/practice/isbn-verifier/.meta/example.lisp
+++ b/exercises/practice/isbn-verifier/.meta/example.lisp
@@ -4,14 +4,13 @@
 
 (in-package :isbn-verifier)
 
+(defun char-to-num (input-char)
+  (if (char= #\X input-char) 10 (digit-char-p input-char)))
+
 (defun validp (isbn)
   (let ((cleaned (remove-if-not #'alphanumericp isbn)))
     (when (= 10 (length cleaned)) ; Check isbn is 10 chars long
       (let ((num-list (map 'list #'char-to-num cleaned))) ; Map chars to numbers (or nil)
         (unless (some #'null num-list) ; Return nil if any nils in num-list
           (unless (member 10 (butlast num-list)) ; Return nil if any of the first 9 nums eql 10
-            (setq total (apply #'+ (mapcar #'* num-list '(10 9 8 7 6 5 4 3 2 1))))
-            (zerop (mod total 11))))))))
-
-(defun char-to-num (input-char)
-  (if (char= #\X input-char) 10 (digit-char-p input-char)))
+            (zerop (mod (apply #'+ (mapcar #'* num-list '(10 9 8 7 6 5 4 3 2 1))) 11))))))))

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -1,0 +1,57 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
+description = valid isbn
+
+[19f76b53-7c24-45f8-87b8-4604d0ccd248]
+description = invalid isbn check digit
+
+[4164bfee-fb0a-4a1c-9f70-64c6a1903dcd]
+description = valid isbn with a check digit of 10
+
+[3ed50db1-8982-4423-a993-93174a20825c]
+description = check digit is a character other than X
+
+[c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
+description = invalid character in isbn is not treated as zero
+
+[28025280-2c39-4092-9719-f3234b89c627]
+description = X is only valid as a check digit
+
+[f6294e61-7e79-46b3-977b-f48789a4945b]
+description = valid isbn without separating dashes
+
+[185ab99b-3a1b-45f3-aeec-b80d80b07f0b]
+description = isbn without separating dashes and X as check digit
+
+[7725a837-ec8e-4528-a92a-d981dd8cf3e2]
+description = isbn without check digit and dashes
+
+[47e4dfba-9c20-46ed-9958-4d3190630bdf]
+description = too long isbn and no dashes
+
+[737f4e91-cbba-4175-95bf-ae630b41fb60]
+description = too short isbn
+
+[5458a128-a9b6-4ff8-8afb-674e74567cef]
+description = isbn without check digit
+
+[70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7]
+description = check digit of X should not be used for 0
+
+[94610459-55ab-4c35-9b93-ff6ea1a8e562]
+description = empty isbn
+
+[7bff28d4-d770-48cc-80d6-b20b3a0fb46c]
+description = input is 9 characters
+
+[ed6e8d1b-382c-4081-8326-8b772c581fec]
+description = invalid characters are not ignored after checking length
+
+[daad3e58-ce00-4395-8a8e-e3eded1cdc86]
+description = invalid characters are not ignored before checking length
+
+[fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
+description = input is too long but contains a valid isbn

--- a/exercises/practice/isbn-verifier/isbn-verifier-test.lisp
+++ b/exercises/practice/isbn-verifier/isbn-verifier-test.lisp
@@ -1,0 +1,92 @@
+;; Ensures that isbn-verifier.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "isbn-verifier")
+  (quicklisp-client:quickload :fiveam))
+
+;; Defines the testing package with symbols from isbn-verifier and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :isbn-verifier-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
+
+;; Enter the testing package
+(in-package :isbn-verifier-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* isbn-verifier-suite)
+
+(test valid-isbn
+    (let ((isbn "3-598-21508-8"))
+      (is-true (isbn-verifier:validp isbn))))
+
+(test invalid-isbn-check-digit
+    (let ((isbn "3-598-21508-9"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test valid-isbn-with-a-check-digit-of-10
+    (let ((isbn "3-598-21507-X"))
+      (is-true (isbn-verifier:validp isbn))))
+
+(test check-digit-is-a-character-other-than-x
+    (let ((isbn "3-598-21507-A"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test invalid-character-in-isbn-is-not-treated-as-zero
+    (let ((isbn "3-598-P1581-X"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test x-is-only-valid-as-a-check-digit
+    (let ((isbn "3-598-2X507-9"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test valid-isbn-without-separating-dashes
+    (let ((isbn "3598215088"))
+      (is-true (isbn-verifier:validp isbn))))
+
+(test isbn-without-separating-dashes-and-x-as-check-digit
+    (let ((isbn "359821507X"))
+      (is-true (isbn-verifier:validp isbn))))
+
+(test isbn-without-check-digit-and-dashes
+    (let ((isbn "359821507"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test too-long-isbn-and-no-dashes
+    (let ((isbn "3598215078X"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test too-short-isbn
+    (let ((isbn "00"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test isbn-without-check-digit
+    (let ((isbn "3-598-21507"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test check-digit-of-x-should-not-be-used-for-0
+    (let ((isbn "3-598-21515-X"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test empty-isbn
+    (let ((isbn ""))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test input-is-9-characters
+    (let ((isbn "134456729"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test invalid-characters-are-not-ignored-after-checking-length
+    (let ((isbn "3132P34035"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test invalid-characters-are-not-ignored-before-checking-length
+    (let ((isbn "3598P215088"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(test input-is-too-long-but-contains-a-valid-isbn
+    (let ((isbn "98245726788"))
+      (is-false (isbn-verifier:validp isbn))))
+
+(defun run-tests (&optional (test-or-suite 'isbn-verifier-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/isbn-verifier/isbn-verifier.lisp
+++ b/exercises/practice/isbn-verifier/isbn-verifier.lisp
@@ -1,0 +1,7 @@
+(defpackage :isbn-verifier
+  (:use :cl)
+  (:export :validp))
+
+(in-package :isbn-verifier)
+
+(defun validp (isbn))


### PR DESCRIPTION
## Summary

Generated practice exercise Isbn Verifier.

Difficulty = 5.  This is the same kind of exercise as Luhn, though there does seem to be a bit more checking required to get this right.  Could be raised to a 6.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
