### PR TITLE
Updated foregone exercises in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -572,7 +572,7 @@
         "status": "beta"
       }
     ],
-    "foregone": ["accumulate", "bank-account"]
+    "foregone": ["accumulate", "bank-account", "list-ops", "linked-list", "simple-linked-list"]
   },
   "concepts": [
     {


### PR DESCRIPTION
## Summary

Reasons:
- list-ops: functions to implement are already fundamental components of Common Lisp (plus naming conflicts might ensue)
- linked-list and simple-linked-list: Student already deals with linked lists all the time - that's how Lisp works.  It would be asking someone to build a linked list by using linked lists.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
