### PR TITLE
Create exercise pig-latin

### DIFF
--- a/config.json
+++ b/config.json
@@ -570,6 +570,15 @@
         "practices": ["lists", "mapping", "functions"],
         "prerequisites": ["conditionals", "lists", "mapping", "arithmetic", "functions"],
         "status": "beta"
+      },
+      {
+        "slug": "pig-latin",
+        "name": "Pig Latin",
+        "uuid": "761dc40f-7142-4f0c-abc8-a05042600f42",
+        "difficulty": 6,
+        "practices": ["strings", "functions"],
+        "prerequisites": ["strings", "functions", "lists", "format-basics"],
+        "status": "beta"
       }
     ],
     "foregone": ["accumulate", "bank-account"]

--- a/exercises/practice/pig-latin/.docs/instructions.md
+++ b/exercises/practice/pig-latin/.docs/instructions.md
@@ -1,0 +1,18 @@
+# Instructions
+
+Implement a program that translates from English to Pig Latin.
+
+Pig Latin is a made-up children's language that's intended to be
+confusing. It obeys a few simple rules (below), but when it's spoken
+quickly it's really difficult for non-children (and non-native speakers)
+to understand.
+
+- **Rule 1**: If a word begins with a vowel sound, add an "ay" sound to the end of the word. Please note that "xr" and "yt" at the beginning of a word make vowel sounds (e.g. "xray" -> "xrayay", "yttria" -> "yttriaay").
+- **Rule 2**: If a word begins with a consonant sound, move it to the end of the word and then add an "ay" sound to the end of the word. Consonant sounds can be made up of multiple consonants, a.k.a. a consonant cluster (e.g. "chair" -> "airchay").
+- **Rule 3**: If a word starts with a consonant sound followed by "qu", move it to the end of the word, and then add an "ay" sound to the end of the word (e.g. "square" -> "aresquay").
+- **Rule 4**: If a word contains a "y" after a consonant cluster or as the second letter in a two letter word it makes a vowel sound (e.g. "rhythm" -> "ythmrhay", "my" -> "ymay").
+
+There are a few more rules for edge cases, and there are regional
+variants too.
+
+See <http://en.wikipedia.org/wiki/Pig_latin> for more details.

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,0 +1,12 @@
+{
+   "blurb": "Implement a program that translates from English to Pig Latin.",
+   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
+   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/",
+   "files": {
+      "test": ["pig-latin-test.lisp"],
+      "solution": ["pig-latin.lisp"],
+      "example": [".meta/example.lisp"]
+   },
+   "authors": ["PaulT89"],
+   "contributors": []
+}

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -8,5 +8,5 @@
       "example": [".meta/example.lisp"]
    },
    "authors": ["PaulT89"],
-   "contributors": []
+   "contributors": ["verdammelt"]
 }

--- a/exercises/practice/pig-latin/.meta/example.lisp
+++ b/exercises/practice/pig-latin/.meta/example.lisp
@@ -6,23 +6,6 @@
 
 (defparameter +vowels+ '("a" "e" "i" "o" "u" "xr" "yt"))
 
-(defun translate (phrase)
-  (loop for word in (split-string phrase)
-    collect (translate-word word) into output
-    finally (return (format nil "~{~A~^ ~}" output))))
-
-(defun translate-word (word)
-  (let ((index (take-consonants word)))
-    (format nil "~A~Aay" (subseq word index) (subseq word 0 index))))
-
-(defun take-consonants (word &optional (index 0))
-  (let ((stopp (lambda (w i) (or (starts-with-p w +vowels+)
-                                 (and (char= #\y (char w 0)) (= 1 i))))))
-    (cond
-      ((funcall stopp word index) index)
-      ((starts-with-p word '("qu")) (take-consonants (subseq word 2) (+ 2 index)))
-      (t (take-consonants (subseq word 1) (1+ index))))))
-
 (defun split-string (str)
   (unless (zerop (length str))
     (let* ((split-at (position #\space str))
@@ -35,3 +18,21 @@
     (case (search (car search-list) word)
       (0 T)
       (otherwise (starts-with-p word (cdr search-list))))))
+
+(defun stop-p (word index)
+  (or (starts-with-p word +vowels+) (and (char= #\y (char word 0)) (= 1 index))))
+
+(defun take-consonants (word &optional (index 0))
+  (cond
+    ((stop-p word index) index)
+    ((starts-with-p word '("qu")) (take-consonants (subseq word 2) (+ 2 index)))
+    (t (take-consonants (subseq word 1) (1+ index)))))
+
+(defun translate-word (word)
+  (let ((index (take-consonants word)))
+    (format nil "~A~Aay" (subseq word index) (subseq word 0 index))))
+
+(defun translate (phrase)
+  (loop for word in (split-string phrase)
+    collect (translate-word word) into output
+    finally (return (format nil "~{~A~^ ~}" output))))

--- a/exercises/practice/pig-latin/.meta/example.lisp
+++ b/exercises/practice/pig-latin/.meta/example.lisp
@@ -1,0 +1,37 @@
+(defpackage :pig-latin
+  (:use :cl)
+  (:export :translate))
+
+(in-package :pig-latin)
+
+(defparameter +vowels+ '("a" "e" "i" "o" "u" "xr" "yt"))
+
+(defun translate (phrase)
+  (loop for word in (split-string phrase)
+    collect (translate-word word) into output
+    finally (return (format nil "~{~A~^ ~}" output))))
+
+(defun translate-word (word)
+  (let ((index (take-consonants word)))
+    (format nil "~A~Aay" (subseq word index) (subseq word 0 index))))
+
+(defun take-consonants (word &optional (index 0))
+  (let ((stopp (lambda (w i) (or (starts-with-p w +vowels+)
+                                 (and (char= #\y (char w 0)) (= 1 i))))))
+    (cond
+      ((funcall stopp word index) index)
+      ((starts-with-p word '("qu")) (take-consonants (subseq word 2) (+ 2 index)))
+      (t (take-consonants (subseq word 1) (1+ index))))))
+
+(defun split-string (str)
+  (unless (zerop (length str))
+    (let* ((split-at (position #\space str))
+           (word (subseq str 0 split-at))
+           (rest-str (string-left-trim " " (subseq str (length word)))))
+      (cons word (split-string rest-str)))))
+
+(defun starts-with-p (word search-list)
+  (when search-list
+    (case (search (car search-list) word)
+      (0 T)
+      (otherwise (starts-with-p word (cdr search-list))))))

--- a/exercises/practice/pig-latin/.meta/tests.toml
+++ b/exercises/practice/pig-latin/.meta/tests.toml
@@ -1,0 +1,69 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[11567f84-e8c6-4918-aedb-435f0b73db57]
+description = word beginning with a
+
+[f623f581-bc59-4f45-9032-90c3ca9d2d90]
+description = word beginning with e
+
+[7dcb08b3-23a6-4e8a-b9aa-d4e859450d58]
+description = word beginning with i
+
+[0e5c3bff-266d-41c8-909f-364e4d16e09c]
+description = word beginning with o
+
+[614ba363-ca3c-4e96-ab09-c7320799723c]
+description = word beginning with u
+
+[bf2538c6-69eb-4fa7-a494-5a3fec911326]
+description = word beginning with a vowel and followed by a qu
+
+[e5be8a01-2d8a-45eb-abb4-3fcc9582a303]
+description = word beginning with p
+
+[d36d1e13-a7ed-464d-a282-8820cb2261ce]
+description = word beginning with k
+
+[d838b56f-0a89-4c90-b326-f16ff4e1dddc]
+description = word beginning with x
+
+[bce94a7a-a94e-4e2b-80f4-b2bb02e40f71]
+description = word beginning with q without a following u
+
+[c01e049a-e3e2-451c-bf8e-e2abb7e438b8]
+description = word beginning with ch
+
+[9ba1669e-c43f-4b93-837a-cfc731fd1425]
+description = word beginning with qu
+
+[92e82277-d5e4-43d7-8dd3-3a3b316c41f7]
+description = word beginning with qu and a preceding consonant
+
+[79ae4248-3499-4d5b-af46-5cb05fa073ac]
+description = word beginning with th
+
+[e0b3ae65-f508-4de3-8999-19c2f8e243e1]
+description = word beginning with thr
+
+[20bc19f9-5a35-4341-9d69-1627d6ee6b43]
+description = word beginning with sch
+
+[54b796cb-613d-4509-8c82-8fbf8fc0af9e]
+description = word beginning with yt
+
+[8c37c5e1-872e-4630-ba6e-d20a959b67f6]
+description = word beginning with xr
+
+[a4a36d33-96f3-422c-a233-d4021460ff00]
+description = y is treated like a consonant at the beginning of a word
+
+[adc90017-1a12-4100-b595-e346105042c7]
+description = y is treated like a vowel at the end of a consonant cluster
+
+[29b4ca3d-efe5-4a95-9a54-8467f2e5e59a]
+description = y as second letter in two letter word
+
+[44616581-5ce3-4a81-82d0-40c7ab13d2cf]
+description = a whole phrase

--- a/exercises/practice/pig-latin/pig-latin-test.lisp
+++ b/exercises/practice/pig-latin/pig-latin-test.lisp
@@ -1,0 +1,108 @@
+;; Ensures that pig-latin.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "pig-latin")
+  (quicklisp-client:quickload :fiveam))
+
+;; Defines the testing package with symbols from pig-latin and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :pig-latin-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
+
+;; Enter the testing package
+(in-package :pig-latin-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* pig-latin-suite)
+
+(test word-beginning-with-a
+    (let ((phrase "apple"))
+      (is (string= "appleay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-e
+    (let ((phrase "ear"))
+      (is (string= "earay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-i
+    (let ((phrase "igloo"))
+      (is (string= "iglooay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-o
+    (let ((phrase "object"))
+      (is (string= "objectay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-u
+    (let ((phrase "under"))
+      (is (string= "underay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-a-vowel-and-followed-by-a-qu
+    (let ((phrase "equal"))
+      (is (string= "equalay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-p
+    (let ((phrase "pig"))
+      (is (string= "igpay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-k
+    (let ((phrase "koala"))
+      (is (string= "oalakay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-x
+    (let ((phrase "xenon"))
+      (is (string= "enonxay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-q-without-a-following-u
+    (let ((phrase "qat"))
+      (is (string= "atqay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-ch
+    (let ((phrase "chair"))
+      (is (string= "airchay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-qu
+    (let ((phrase "queen"))
+      (is (string= "eenquay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-qu-and-a-preceding-consonant
+    (let ((phrase "square"))
+      (is (string= "aresquay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-th
+    (let ((phrase "therapy"))
+      (is (string= "erapythay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-thr
+    (let ((phrase "thrush"))
+      (is (string= "ushthray" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-sch
+    (let ((phrase "school"))
+      (is (string= "oolschay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-yt
+    (let ((phrase "yttria"))
+      (is (string= "yttriaay" (pig-latin:translate phrase)))))
+
+(test word-beginning-with-xr
+    (let ((phrase "xray"))
+      (is (string= "xrayay" (pig-latin:translate phrase)))))
+
+(test y-is-treated-like-a-consonant-at-the-beginning-of-a-word
+    (let ((phrase "yellow"))
+      (is (string= "ellowyay" (pig-latin:translate phrase)))))
+
+(test y-is-treated-like-a-vowel-at-the-end-of-a-consonant-cluster
+    (let ((phrase "rhythm"))
+      (is (string= "ythmrhay" (pig-latin:translate phrase)))))
+
+(test y-as-second-letter-in-two-letter-word
+    (let ((phrase "my"))
+      (is (string= "ymay" (pig-latin:translate phrase)))))
+
+(test a-whole-phrase
+    (let ((phrase "quick fast run"))
+      (is (string= "ickquay astfay unray" (pig-latin:translate phrase)))))
+
+(defun run-tests (&optional (test-or-suite 'pig-latin-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/pig-latin/pig-latin.lisp
+++ b/exercises/practice/pig-latin/pig-latin.lisp
@@ -1,0 +1,7 @@
+(defpackage :pig-latin
+  (:use :cl)
+  (:export :translate))
+
+(in-package :pig-latin)
+
+(defun translate (phrase))


### PR DESCRIPTION
## Summary

Generated practice exercise Pig Latin.

Difficulty = 6.  This is higher than other tracks.  Ruby and Rust, for example, have this set at 4, however these languages have lots of string helper functions that Common Lisp doesn't have (e.g. split, join, starts with, etc.).  The extra difficulty comes from having to make your own helper functions.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
