### PR TITLE
[Lillys Lasagna Leftovers] Fixed typo

### DIFF
--- a/exercises/concept/lillys-lasagna-leftovers/.docs/introduction.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.docs/introduction.md
@@ -19,7 +19,7 @@ These are designated in the lambda list by `&optional` lambda list keyword.
 A parameter will be bound to the value `nil` if it is not specified.
 If there are several optional parameters they are bound in order.
 Default values can be specified for optional parameters.
-Finally a symbol an be specified for each optional parameter which will be bound to true or false depending on whether that parameter was supplied by the caller of the function (this is referred to as the "supplied-p parameter").
+Finally a symbol can be specified for each optional parameter which will be bound to true or false depending on whether that parameter was supplied by the caller of the function (this is referred to as the "supplied-p parameter").
 
 ```lisp
 (defun optional-parameters (&optional x (y 'default) (z nil z-supplied-p))


### PR DESCRIPTION
## Summary

Changed 'an' to 'can'.  Sentence now makes sense.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
