### PR TITLE
Update foregone list

### DIFF
--- a/config.json
+++ b/config.json
@@ -696,7 +696,8 @@
       "linked-list",
       "simple-linked-list",
       "parallel-letter-frequency",
-      "lens-person"
+      "lens-person",
+      "reverse-string"
      ]
   },
   "concepts": [

--- a/config.json
+++ b/config.json
@@ -689,7 +689,15 @@
         "status": "beta"
       }
     ],
-    "foregone": ["accumulate", "bank-account", "list-ops", "linked-list", "simple-linked-list"]
+    "foregone": [
+      "accumulate",
+      "bank-account",
+      "list-ops",
+      "linked-list",
+      "simple-linked-list",
+      "parallel-letter-frequency",
+      "lens-person"
+     ]
   },
   "concepts": [
     {


### PR DESCRIPTION
## Summary

Reasons:
- parallel-letter-frequency: same as bank-account - exercise is built specifically to practice parallel computation.
- lens-person: Common Lisp doesn't have a 'lens' concept (seems like an exercise specifically built for Haskell).

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
