### PR TITLE
Create exercise pythagorean-triplet

### DIFF
--- a/config.json
+++ b/config.json
@@ -687,6 +687,15 @@
         "practices": ["strings", "arrays"],
         "prerequisites": ["strings", "arrays", "functions", "lists"],
         "status": "beta"
+      },
+      {
+        "slug": "pythagorean-triplet",
+        "name": "Pythagorean Triplet",
+        "uuid": "f7bbf16d-77d9-4d13-a20c-e60f416de764",
+        "difficulty": 6,
+        "practices": ["arithmetic", "lists"],
+        "prerequisites": ["arithmetic", "lists"],
+        "status": "beta"
       }
     ],
     "foregone": ["accumulate", "bank-account", "list-ops", "linked-list", "simple-linked-list"]

--- a/exercises/practice/pythagorean-triplet/.docs/instructions.md
+++ b/exercises/practice/pythagorean-triplet/.docs/instructions.md
@@ -1,0 +1,24 @@
+# Instructions
+
+A Pythagorean triplet is a set of three natural numbers, {a, b, c}, for
+which,
+
+```text
+a² + b² = c²
+```
+
+and such that,
+
+```text
+a < b < c
+```
+
+For example,
+
+```text
+3² + 4² = 9 + 16 = 25 = 5².
+```
+
+Given an input integer N, find all Pythagorean triplets for which `a + b + c = N`.
+
+For example, with N = 1000, there is exactly one Pythagorean triplet for which `a + b + c = 1000`: `{200, 375, 425}`.

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,0 +1,12 @@
+{
+   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
+   "source": "Problem 9 at Project Euler",
+   "source_url": "http://projecteuler.net/problem=9",
+   "files": {
+      "test": ["pythagorean-triplet-test.lisp"],
+      "solution": ["pythagorean-triplet.lisp"],
+      "example": [".meta/example.lisp"]
+   },
+   "authors": ["PaulT89"],
+   "contributors": []
+}

--- a/exercises/practice/pythagorean-triplet/.meta/example.lisp
+++ b/exercises/practice/pythagorean-triplet/.meta/example.lisp
@@ -1,0 +1,15 @@
+(defpackage :pythagorean-triplet
+  (:use :cl)
+  (:export :triplets-with-sum))
+
+(in-package :pythagorean-triplet)
+
+(defun work-triplet (triplet n)
+  (let ((third-on-second (/ (third triplet) (second triplet))))
+    (list (first triplet) (- n (first triplet) third-on-second) third-on-second)))
+
+(defun triplets-with-sum (n)
+  (let* ((unworked-triplets (loop for a from 1 to (floor (/ (* 2 n) 7))
+                              collect (list a (* 2 (- n a)) (- (+ (* 2 a a) (* n n)) (* 2 n a)))))
+         (filtered (remove-if (lambda (x) (plusp (mod (third x) (second x)))) unworked-triplets)))
+    (mapcar (lambda (x) (work-triplet x n)) filtered)))

--- a/exercises/practice/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/practice/pythagorean-triplet/.meta/tests.toml
@@ -1,0 +1,24 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[a19de65d-35b8-4480-b1af-371d9541e706]
+description = triplets whose sum is 12
+
+[48b21332-0a3d-43b2-9a52-90b2a6e5c9f5]
+description = triplets whose sum is 108
+
+[dffc1266-418e-4daa-81af-54c3e95c3bb5]
+description = triplets whose sum is 1000
+
+[5f86a2d4-6383-4cce-93a5-e4489e79b186]
+description = no matching triplets for 1001
+
+[bf17ba80-1596-409a-bb13-343bdb3b2904]
+description = returns all matching triplets
+
+[9d8fb5d5-6c6f-42df-9f95-d3165963ac57]
+description = several matching triplets
+
+[f5be5734-8aa0-4bd1-99a2-02adcc4402b4]
+description = triplets for large number

--- a/exercises/practice/pythagorean-triplet/pythagorean-triplet-test.lisp
+++ b/exercises/practice/pythagorean-triplet/pythagorean-triplet-test.lisp
@@ -1,0 +1,61 @@
+;; Ensures that pythagorean-triplet.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "pythagorean-triplet")
+  (quicklisp-client:quickload :fiveam))
+
+;; Defines the testing package with symbols from pythagorean-triplet and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :pythagorean-triplet-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
+
+;; Enter the testing package
+(in-package :pythagorean-triplet-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* pythagorean-triplet-suite)
+
+(test triplets-whose-sum-is-12
+    (let ((n 12))
+      (is (equal '((3 4 5)) (pythagorean-triplet:triplets-with-sum n)))))
+
+(test triplets-whose-sum-is-108
+    (let ((n 108))
+      (is (equal '((27 36 45)) (pythagorean-triplet:triplets-with-sum n)))))
+
+(test triplets-whose-sum-is-1000
+    (let ((n 1000))
+      (is (equal '((200 375 425)) (pythagorean-triplet:triplets-with-sum n)))))
+
+(test no-matching-triplets-for-1001
+    (let ((n 1001))
+      (is (equal '() (pythagorean-triplet:triplets-with-sum n)))))
+
+(test returns-all-matching-triplets
+    (let ((n 90))
+      (is (equal '((9 40 41) (15 36 39)) (pythagorean-triplet:triplets-with-sum n)))))
+
+(test several-matching-triplets
+    (let ((n 840)
+          (result '((40 399 401)
+                    (56 390 394)
+                    (105 360 375)
+                    (120 350 370)
+                    (140 336 364)
+                    (168 315 357)
+                    (210 280 350)
+                    (240 252 348))))
+      (is (equal result (pythagorean-triplet:triplets-with-sum n)))))
+
+(test triplets-for-large-number
+    (let ((n 30000)
+          (result '((1200 14375 14425)
+                    (1875 14000 14125)
+                    (5000 12000 13000)
+                    (6000 11250 12750)
+                    (7500 10000 12500))))
+      (is (equal result (pythagorean-triplet:triplets-with-sum n)))))
+
+(defun run-tests (&optional (test-or-suite 'pythagorean-triplet-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/pythagorean-triplet/pythagorean-triplet.lisp
+++ b/exercises/practice/pythagorean-triplet/pythagorean-triplet.lisp
@@ -1,0 +1,7 @@
+(defpackage :pythagorean-triplet
+  (:use :cl)
+  (:export :triplets-with-sum))
+
+(in-package :pythagorean-triplet)
+
+(defun triplets-with-sum (n))


### PR DESCRIPTION
## Summary

Generated practice exercise Pythagorean Triplet.

Difficulty = 6.  This is around what other tracks have this set at.  Rust has it 7 and Ruby at 5, though, oddly enough, I found it harder to do in Ruby than in Rust.

## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
