### PR TITLE
Remove assumptions about characters.

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,6 +1,7 @@
 {
   "authors": [
-    "verdammelt"
+    "verdammelt",
+    "PaulT89"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/atbash-cipher/.meta/example.lisp
+++ b/exercises/practice/atbash-cipher/.meta/example.lisp
@@ -15,23 +15,13 @@
                (zerop (mod i group-size)))
      collect #\Space))
 
-(defparameter +null-character+ (code-char 0))
+(defparameter +key+
+  (pairlis
+   (coerce "abcdefghijklmnopqrstuvwxyz1234567890" 'list)
+   (coerce "zyxwvutsrqponmlkjihgfedcba1234567890" 'list)))
 
-(defun cleanup-ciphered-sequence (seq)
-  (remove +null-character+ seq))
-
-(defun opposite-char (c)
-  (let* ((alphabet "abcdefghijklmnopqrstuvwxyz")
-         (reverse (reverse alphabet)))
-    (char reverse (position c alphabet))))
-
-(defun encipher (c)
-  (cond ((alpha-char-p c) (opposite-char (char-downcase c)))
-        ((digit-char-p c) c)
-        (t +null-character+)))
-
-(defun to-cipher-sequence (plaintext)
-  (cleanup-ciphered-sequence (map 'list #'encipher plaintext)))
+(defun lookup-char (c) (cdr (assoc c +key+)))
 
 (defun encode (plaintext)
-  (to-string (group (to-cipher-sequence plaintext))))
+  (let ((filtered (remove-if-not #'alphanumericp (string-downcase plaintext))))
+     (to-string (group (map 'list #'lookup-char filtered)))))

--- a/exercises/practice/atbash-cipher/.meta/example.lisp
+++ b/exercises/practice/atbash-cipher/.meta/example.lisp
@@ -15,19 +15,20 @@
                (zerop (mod i group-size)))
      collect #\Space))
 
+(defparameter +null-character+ (code-char 0))
+
 (defun cleanup-ciphered-sequence (seq)
-  (remove (code-char 0) seq))
+  (remove +null-character+ seq))
 
 (defun opposite-char (c)
-  (code-char
-   (- (char-code #\z)
-      (- (char-code c)
-         (char-code #\a)))))
+  (let* ((alphabet "abcdefghijklmnopqrstuvwxyz")
+         (reverse (reverse alphabet)))
+    (char reverse (position c alphabet))))
 
 (defun encipher (c)
   (cond ((alpha-char-p c) (opposite-char (char-downcase c)))
         ((digit-char-p c) c)
-        (t (code-char 0))))
+        (t +null-character+)))
 
 (defun to-cipher-sequence (plaintext)
   (cleanup-ciphered-sequence (map 'list #'encipher plaintext)))

--- a/exercises/practice/diamond/.meta/example.lisp
+++ b/exercises/practice/diamond/.meta/example.lisp
@@ -4,8 +4,10 @@
 
 (in-package :diamond)
 
+(defparameter +alphabet+ (coerce "ABCDEFGHIJKLMNOPQRSTUVWXYZ" 'list))
+
 (defun rows (letter)
-  (let* ((letters (loop for i from 65 to (char-code letter) collect (code-char i)))
+  (let* ((letters (subseq +alphabet+ 0 (1+ (position letter +alphabet+))))
          (columns (1- (* 2 (length letters))))
          (unique-rows (loop for c in letters and idx from 0
                         collect (let ((mid-space (abs (1- (* 2 idx)))))

--- a/exercises/practice/robot-name/.meta/example.lisp
+++ b/exercises/practice/robot-name/.meta/example.lisp
@@ -5,9 +5,12 @@
 (in-package :robot-name)
 
 (defun random-alpha-char ()
-  (code-char (+ (char-code #\A) (random 26))))
+  (let ((alphabet "ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+    (char alphabet (random 26))))
+
 (defun random-digit-char ()
-  (code-char (+ (char-code #\0) (random 10))))
+  (let ((digits "0123456789"))
+    (char digits (random 10))))
 
 (defun random-robot-name ()
   (concatenate 'string (list (random-alpha-char)

--- a/exercises/practice/robot-name/robot-name-test.lisp
+++ b/exercises/practice/robot-name/robot-name-test.lisp
@@ -15,16 +15,12 @@
 ;; Define and enter a new FiveAM test-suite
 (def-suite* robot-name-suite)
 
-(defun is-upper-alpha-p (c) (char<= #\A c #\Z))
-
-(defun is-digit-p (c) (char-not-greaterp #\0 c #\9))
-
 (test name-matches-expected-pattern
   (let* ((robbie (robot-name:build-robot))
          (name (robot-name:robot-name robbie)))
    (is (= 5 (length name)))
-   (is (every #'is-upper-alpha-p (subseq name 0 2)))
-   (is (every #'is-digit-p (subseq name 2 5)))))
+   (is (every #'upper-case-p (subseq name 0 2)))
+   (is (every #'digit-char-p (subseq name 2 5)))))
 
 (test name-is-persistent
   (let ((robbie (robot-name:build-robot)))


### PR DESCRIPTION
The Common Lisp specification does not specify the exact ordering of
characters. So we should not assume ASCII or that all
upper/lower/digit characters are contiguous.

-------

## Summary

(Explain what this change is attempting to accomplish)


## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green