### PR TITLE
Fixed TOML generation

### DIFF
--- a/bin/lisp_exercise_generator.py
+++ b/bin/lisp_exercise_generator.py
@@ -283,7 +283,7 @@ def create_test_toml(exercise_name, prob_spec_exercise):
         for case in cases:
             try:
                 # Add lines in toml style
-                output += "\n[{0}]\ndescription = {1}\n".format(case["uuid"], case["description"])
+                output += "\n[{0}]\ndescription = \"{1}\"\n".format(case["uuid"], case["description"])
             except KeyError:
                 # Recursively dig further into the data structure
                 output += find_uuids_and_descriptions(case["cases"])


### PR DESCRIPTION
## Summary

Fixes issue #650.  Descriptions are now in quotes.


## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
