### PR TITLE
ran-transcription example was more complicated than needed.

### DIFF
--- a/exercises/practice/rna-transcription/.meta/example.lisp
+++ b/exercises/practice/rna-transcription/.meta/example.lisp
@@ -14,6 +14,4 @@
 
 (defun to-rna (strand)
   (validate-strand strand)
-  (concatenate 'string
-               (mapcar #'(lambda (c) (cdr (assoc c dna->rna)))
-                       (coerce strand 'list))))
+  (map 'string #'(lambda (c) (cdr (assoc c dna->rna))) strand))


### PR DESCRIPTION
## Summary

Simplifying the ran-transcription example shows that this exercise is all about mapping and little else. (error signaling and lists are not yet concepts - when they are we'll include them.)

## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
