### PR TITLE
Fix typo for example output in vector

### DIFF
--- a/concepts/vectors/about.md
+++ b/concepts/vectors/about.md
@@ -16,7 +16,7 @@ Since they are arrays they can also be created with `make-array`:
 
 ```lisp
 (make-array 3 :initial-element 'x)        ; => #(X X X)
-(make-array 3 :initial-contents '(a b c)) ; => #(A B C D)
+(make-array 3 :initial-contents '(a b c)) ; => #(A B C)
 ```
 
 ## Vector Predicate


### PR DESCRIPTION
Fix typo in the docs: `(make-array 3 :initial-contents '(a b c))` returns `#(A B C)`, not `#(A B C D)`
