### PR TITLE
Add documentation about what the representer does.

### DIFF
--- a/docs/REPRESENTER_NORMALIZATIONS.md
+++ b/docs/REPRESENTER_NORMALIZATIONS.md
@@ -1,11 +1,11 @@
 # Representer normalizations
 
-The [representer][representer] uses `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
-In total each submission has the following normalizations applied to it:
+The [representer][representer] uses `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation, as well as applying some additional normalizations.
+Each submission has the following normalizations applied to it:
 
 ## Remove comments
 
-The submission is `[read][cl-read]` in and so all comments are removed.
+Because `[read][cl-read]` is used to load the submission, comments are removed.
 
 ## Remove documentation strings
 
@@ -14,7 +14,7 @@ However the representation will note if a documentation string was present or no
 
 ## Normalize text case
 
-The submission is `[read][cl-read]` in and so all symbols are normalized to uppercase.
+Because `[read][cl-read]` is used to load the submission, all symbols are normalized to uppercase.
 
 ## Normalize text formatting
 

--- a/docs/REPRESENTER_NORMALIZATIONS.md
+++ b/docs/REPRESENTER_NORMALIZATIONS.md
@@ -1,6 +1,6 @@
 # Representer normalizations
 
-The [representer][representer] use `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
+The [representer][representer] uses `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
 In total each submission has the following normalizations applied to it:
 
 ## Remove comments

--- a/docs/REPRESENTER_NORMALIZATIONS.md
+++ b/docs/REPRESENTER_NORMALIZATIONS.md
@@ -1,0 +1,30 @@
+# Representer normalizations
+
+The [representer][representer] use `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
+In total each submission has the following normalizations applied to it:
+
+## Remove comments
+
+The submission is `[read][cl-read]` in and so all comments are removed.
+
+## Remove documentation strings
+
+Instead of normalizing any names which may be present in the documentation string the string is removed. 
+However the representation will note if a documentation string was present or not. 
+
+## Normalize text case
+
+The submission is `[read][cl-read]` in and so all symbols are normalized to uppercase.
+
+## Normalize text formatting
+
+The representation is written with `[write][cl-write]` so any particulars of the submissions formatting (such as indentation, spacing, leaving closing parenthesis on empty lines) are not retained in the representation.
+
+## Normalize symbol names
+
+Symbols such as function, variable and macro names as well packages are mapped to `[gensyms][cl-gensym]` which are used in the representation.
+
+[cl-gensym]: http://www.lispworks.com/documentation/HyperSpec/Body/f_gensym.htm
+[cl-read]: http://www.lispworks.com/documentation/HyperSpec/Body/f_rd_rd.htm
+[cl-write]: http://www.lispworks.com/documentation/HyperSpec/Body/f_wr_pr.htm
+[representer]: https://github.com/exercism/common-lisp-representer

--- a/docs/config.json
+++ b/docs/config.json
@@ -28,7 +28,7 @@
       "title": "Useful Common Lisp resources",
       "blurb": "A collection of useful resources to help you master Common Lisp"
     },
-        {
+    {
        "uuid": "5e4cdf80-0347-418e-914e-56d1bbecde01",
        "slug": "representer-normalizations",
        "path": "docs/REPRESENTER_NORMALIZATIONS.md",

--- a/docs/config.json
+++ b/docs/config.json
@@ -27,6 +27,13 @@
       "path": "docs/RESOURCES.md",
       "title": "Useful Common Lisp resources",
       "blurb": "A collection of useful resources to help you master Common Lisp"
-    }
+    },
+        {
+       "uuid": "5e4cdf80-0347-418e-914e-56d1bbecde01",
+       "slug": "representer-normalizations",
+       "path": "docs/REPRESENTER_NORMALIZATIONS.md",
+       "title": "Common Lisp representer normalizations",
+       "blurb": "An overview of the normalizations the Common Lisp representer applies to solutions"
+     }
   ]
 }

--- a/exercises/shared/.docs/representations.md
+++ b/exercises/shared/.docs/representations.md
@@ -1,6 +1,6 @@
 # Representations
 
-The [representer][representer] use `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
+The [representer][representer] uses `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
 In total each submission has the following normalizations applied to it:
 
 - [All comments are removed][remove-comments]

--- a/exercises/shared/.docs/representations.md
+++ b/exercises/shared/.docs/representations.md
@@ -1,0 +1,19 @@
+# Representations
+
+The [representer][representer] use `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
+In total each submission has the following normalizations applied to it:
+
+- [All comments are removed][remove-comments]
+- [Documentation strings are removed][remove-doc-strings]
+- [Text case is normalized][normalize-case]
+- [Text formatting is normalized][normalize-formatting]
+- [Symbol names are normalized][normalize-names]
+
+[cl-read]: http://www.lispworks.com/documentation/HyperSpec/Body/f_rd_rd.htm
+[cl-write]: http://www.lispworks.com/documentation/HyperSpec/Body/f_wr_pr.htm
+[normalize-case]: https://exercism.org/docs/tracks/common-lisp/representer-normalizations#h-normalize-text-case
+[normalize-formatting]: https://exercism.org/docs/tracks/common-lisp/representer-normalizations#h-normalize-text-formatting
+[normalize-names]: https://exercism.org/docs/tracks/common-lisp/representer-normalizations#h-normalize-symbol-names
+[remove-comments]: https://exercism.org/docs/tracks/common-lisp/representer-normalizations#h-remove-comments
+[remove-doc-strings]: https://exercism.org/docs/tracks/common-lisp/representer-normalizations#h-remove-documentation-strings
+[representer]: https://github.com/exercism/common-lisp-representer

--- a/exercises/shared/.docs/representations.md
+++ b/exercises/shared/.docs/representations.md
@@ -1,7 +1,7 @@
 # Representations
 
-The [representer][representer] uses `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation as well as applying some additional normalizations.
-In total each submission has the following normalizations applied to it:
+The [representer][representer] uses `[read][cl-read]` to read the submission and `[write][cl-write]` to write the representation, as well as applying some additional normalizations.
+Each submission has the following normalizations applied to it:
 
 - [All comments are removed][remove-comments]
 - [Documentation strings are removed][remove-doc-strings]


### PR DESCRIPTION
This information is shown in the track's documentation pages and, more importantly, the summary is shown to the mentor writing representations.