### PR TITLE
Missing Test Cases

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -28,3 +28,10 @@ description = "Seven digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
 description = "Seven digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"
+

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-test.lisp
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-test.lisp
@@ -39,6 +39,12 @@
 (test seven-digit-number-that-is-not-an-armstrong-number
  (is (equal 'nil (armstrong-numbers:armstrong-number-p 9926314))))
 
+(test armstrong-number-containing-seven-zeroes
+ (is (equal t (armstrong-numbers:armstrong-number-p 186709961001538790100634132976990))))
+
+(test the-largest-and-last-armstrong-number
+ (is (equal t (armstrong-numbers:armstrong-number-p 115132219018763992565095597973971522401))))
+
 (defun run-tests (&optional (test-or-suite 'armstrong-numbers-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-test.lisp
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-test.lisp
@@ -48,3 +48,4 @@
 (defun run-tests (&optional (test-or-suite 'armstrong-numbers-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))
+

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -5,6 +5,9 @@
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
 
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
+
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
 

--- a/exercises/practice/crypto-square/crypto-square-test.lisp
+++ b/exercises/practice/crypto-square/crypto-square-test.lisp
@@ -44,3 +44,4 @@
 (defun run-tests (&optional (test-or-suite 'crypto-square-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))
+

--- a/exercises/practice/crypto-square/crypto-square-test.lisp
+++ b/exercises/practice/crypto-square/crypto-square-test.lisp
@@ -18,6 +18,9 @@
 (test empty-plaintext-results-in-an-empty-ciphertext
  (is (equal "" (crypto-square:encipher ""))))
 
+(test normalization-results-in-empty-plaintext
+ (is (equal "" (crypto-square:encipher "... --- ..."))))
+
 (test lowercase (is (equal "a" (crypto-square:encipher "A"))))
 
 (test remove-spaces (is (equal "b" (crypto-square:encipher "  b "))))

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -32,6 +32,9 @@ description = "several paired brackets"
 [2e1f7b56-c137-4c92-9781-958638885a44]
 description = "paired and nested brackets"
 
+[1d5c093f-fc84-41fb-8c2a-e052f9581602]
+description = "paired and wrong nested brackets but innermost are correct"
+
 [84f6233b-e0f7-4077-8966-8085d295c19b]
 description = "unopened closing brackets"
 

--- a/exercises/practice/matching-brackets/matching-brackets-test.lisp
+++ b/exercises/practice/matching-brackets/matching-brackets-test.lisp
@@ -55,6 +55,10 @@
     (let ((value "([{}({}[])])"))
      (is-true (matching-brackets:pairedp value))))
 
+(test paired-and-wrong-nested-brackets-but-innermost-are-correct
+    (let ((value "[({}])"))
+     (is-false (matching-brackets:pairedp value))))
+
 (test unopened-closing-brackets
     (let ((value "{[)][]}"))
      (is-false (matching-brackets:pairedp value))))

--- a/exercises/practice/matching-brackets/matching-brackets-test.lisp
+++ b/exercises/practice/matching-brackets/matching-brackets-test.lisp
@@ -98,3 +98,4 @@
 (defun run-tests (&optional (test-or-suite 'matching-brackets-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))
+

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -80,3 +80,10 @@ description = "666 is DCLXVI"
 
 [efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
 description = "1666 is MDCLXVI"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"
+

--- a/exercises/practice/roman-numerals/roman-numerals-test.lisp
+++ b/exercises/practice/roman-numerals/roman-numerals-test.lisp
@@ -87,6 +87,12 @@
 (test test-3000
   (is (string= "MMM" (roman-numerals:romanize 3000))))
 
+(test test-3001
+  (is (string= "MMMI" (roman-numerals:romanize 3001))))
+
+(test test-3999
+  (is (string= "MMMCMXCIX" (roman-numerals:romanize 3999))))
+
 (defun run-tests (&optional (test-or-suite 'roman-numerals-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))

--- a/exercises/practice/roman-numerals/roman-numerals-test.lisp
+++ b/exercises/practice/roman-numerals/roman-numerals-test.lisp
@@ -96,3 +96,4 @@
 (defun run-tests (&optional (test-or-suite 'roman-numerals-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))
+

--- a/exercises/practice/say/.meta/tests.toml
+++ b/exercises/practice/say/.meta/tests.toml
@@ -17,11 +17,23 @@ description = "twenty"
 [d78601eb-4a84-4bfa-bf0e-665aeb8abe94]
 description = "twenty-two"
 
+[f010d4ca-12c9-44e9-803a-27789841adb1]
+description = "thirty"
+
+[738ce12d-ee5c-4dfb-ad26-534753a98327]
+description = "ninety-nine"
+
 [e417d452-129e-4056-bd5b-6eb1df334dce]
 description = "one hundred"
 
 [d6924f30-80ba-4597-acf6-ea3f16269da8]
 description = "one hundred twenty-three"
+
+[2f061132-54bc-4fd4-b5df-0a3b778959b9]
+description = "two hundred"
+
+[feed6627-5387-4d38-9692-87c0dbc55c33]
+description = "nine hundred ninety-nine"
 
 [3d83da89-a372-46d3-b10d-de0c792432b3]
 description = "one thousand"

--- a/exercises/practice/say/say-test.lisp
+++ b/exercises/practice/say/say-test.lisp
@@ -95,3 +95,4 @@
 (defun run-tests (&optional (test-or-suite 'say-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))
+

--- a/exercises/practice/say/say-test.lisp
+++ b/exercises/practice/say/say-test.lisp
@@ -35,6 +35,14 @@
     (let ((number 22))
       (is (string= "twenty-two" (say:say number)))))
 
+(test thirty
+    (let ((number 30))
+      (is (string= "thirty" (say:say number)))))
+
+(test ninety-nine
+    (let ((number 99))
+      (is (string= "ninety-nine" (say:say number)))))
+
 (test one-hundred
     (let ((number 100))
       (is (string= "one hundred" (say:say number)))))
@@ -42,6 +50,14 @@
 (test one-hundred-twenty-three
     (let ((number 123))
       (is (string= "one hundred twenty-three" (say:say number)))))
+
+(test two-hundred
+    (let ((number 200))
+      (is (string= "two hundred" (say:say number)))))
+
+(test nine-hundred-ninety-nine
+    (let ((number 999))
+      (is (string= "nine hundred ninety-nine" (say:say number)))))
 
 (test one-thousand
     (let ((number 1000))

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -51,3 +51,7 @@ description = "multiple spaces not detected as a word"
 
 [50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
 description = "alternating word separators not detected as a word"
+
+[6d00f1db-901c-4bec-9829-d20eb3044557]
+description = "quotation for word with apostrophe"
+

--- a/exercises/practice/word-count/word-count-test.lisp
+++ b/exercises/practice/word-count/word-count-test.lisp
@@ -107,6 +107,12 @@ three"))))
  ,two
  'three'"))))
 
+(test quotation-for-word-with-apostrophe
+  (is (assert-alist-equal
+       '(("can" . 1) ("can't" . 2))
+       (word-count:count-words "can, can't, 'can't'"))))
+
 (defun run-tests (&optional (test-or-suite 'word-count-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))
+


### PR DESCRIPTION
This is to help close Issue #668.  Right now I'm just going through and adding these one-by-one in a commit, there are a few that will be here:

* Armstrong Numbers (the initial one)
* Crypto-Square
* ~~Gigaseconds~~ (How the function takes parameters it will not mutate the input)
* Matching Brackets
* Roman Numerals
* Say
* Word Count

These are the ones that I'm seeing when I run `configlet sync --tests --docs --metadata --filepaths` like the bot suggests.  I'll probably get to fixing the docs warning too, but that's another PR.

When done a `hacktoberfest-accepted` label would be nice, thanks!