### PR TITLE
A couple of typos in date-time and multiple-values

### DIFF
--- a/concepts/date-time/about.md
+++ b/concepts/date-time/about.md
@@ -28,7 +28,7 @@ A decoded time is a set of values:
 - *minutes*: an integer between 0 and 59
 - *hour*: an integer between 0 and 23
 - *date*: an integer between 1 and 31 (upper limit actually depends upon month and year obviously)
-- *month*: and integer between 1 and 12
+- *month*: an integer between 1 and 12
 - *year*: an integer indicating the year.
 - *day of week*: an integer between 0 and 6. 0 means Monday, 1 means Tuesday etc. ... 6 means Sunday.
 - *daylight saving time flag*: true value indicates DST is in effect.

--- a/concepts/date-time/introduction.md
+++ b/concepts/date-time/introduction.md
@@ -25,7 +25,7 @@ A decoded time is a set of values:
 - *minutes*: an integer between 0 and 59
 - *hour*: an integer between 0 and 23
 - *date*: an integer between 1 and 31 (upper limit actually depends upon month and year obviously)
-- *month*: and integer between 1 and 12
+- *month*: an integer between 1 and 12
 - *year*: an integer indicating the year.
 - *day of week*: an integer between 0 and 6. 0 means Monday, 1 means Tuesday etc. ... 6 means Sunday.
 - *daylight saving time flag*: true value indicates DST is in effect.

--- a/concepts/multiple-values/about.md
+++ b/concepts/multiple-values/about.md
@@ -48,7 +48,9 @@ The second will let you bind variables to the individual values.
    (+ a b c)) ; => 6
 ```
 
-Another useful macro is `nthvalue`. This is like `nth` for lists in that it returns the "nth" item from a set of multiple values:
+Note that the variables `a`, `b` and `c` are only in scope inside `multiple-values-bind`.
+
+Another useful macro is `nth-value`. This is like `nth` for lists in that it returns the "nth" item from a set of multiple values:
 
 ```lisp
 (nth-value 0 (values 1 2 3 )) ; => 1

--- a/concepts/multiple-values/introduction.md
+++ b/concepts/multiple-values/introduction.md
@@ -40,4 +40,4 @@ The second will let you bind variables to the individual values.
    (+ a b c)) ; => 6
 ```
 
-Another useful function is `nthvalue`
+Another useful function is `nth-value`

--- a/exercises/concept/gigasecond-anniversary/.docs/introduction.md
+++ b/exercises/concept/gigasecond-anniversary/.docs/introduction.md
@@ -27,7 +27,7 @@ A decoded time is a set of values:
 - *minutes*: an integer between 0 and 59
 - *hour*: an integer between 0 and 23
 - *date*: an integer between 1 and 31 (upper limit actually depends upon month and year obviously)
-- *month*: and integer between 1 and 12
+- *month*: an integer between 1 and 12
 - *year*: an integer indicating the year.
 - *day of week*: an integer between 0 and 6. 0 means Monday, 1 means Tuesday etc. ... 6 means Sunday.
 - *daylight saving time flag*: true value indicates DST is in effect.
@@ -98,6 +98,6 @@ The second will let you bind variables to the individual values.
    (+ a b c)) ; => 6
 ```
 
-Another useful function is `nthvalue`
+Another useful function is `nth-value`
 
 [concept-multiple-values]: /tracks/common-lisp/concepts/multiple-values


### PR DESCRIPTION
## Summary

Also, added a sentence about the scope of variables in `multiple-values-bind`.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
