### PR TITLE
pal-picker: A hint about how to compare strings

### DIFF
--- a/exercises/concept/pal-picker/.docs/hints.md
+++ b/exercises/concept/pal-picker/.docs/hints.md
@@ -30,3 +30,4 @@
 - This task requires single-branch conditionals
 - One action is unfitting when `pet` is a particular pet
 - The other action is unfitting unless `pet` is a particular pet
+- For comparing two strings for equality, the `equal` or `string=` functions can be used (the concept of equality is covered later in the syllabus).

--- a/exercises/concept/pal-picker/.docs/hints.md
+++ b/exercises/concept/pal-picker/.docs/hints.md
@@ -30,4 +30,7 @@
 - This task requires single-branch conditionals
 - One action is unfitting when `pet` is a particular pet
 - The other action is unfitting unless `pet` is a particular pet
-- For comparing two strings for equality, the `equal` or `string=` functions can be used (the concept of equality is covered later in the syllabus).
+- For comparing two strings for equality, the `equal` or `string=` functions can be used (you'll see more about this in the [Equality] and [Strings] concepts)
+
+[Equality]: /tracks/common-lisp/concepts/equality
+[Strings]: /tracks/common-lisp/concepts/strings


### PR DESCRIPTION
## Summary

This is a good exercise, the tasks require the various conditional functions quite clearly.

However, it took me a while to crack the last task. Somehow I missed `equal` here: http://www.lispworks.com/documentation/HyperSpec/Front/X_Alph_E.htm

I see that `equality` shows up later in the syllabus. This exercise could use a hint about comparing two strings.
 
This is less of a "hint" and more like "if you're having trouble, use this function".

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
