### PR TITLE
high-scores: to avoid later difficulty, specify the initial score

### DIFF
--- a/exercises/concept/high-scores/.docs/hints.md
+++ b/exercises/concept/high-scores/.docs/hints.md
@@ -7,7 +7,6 @@
 
 ## 2. Adding a player to the table
 
-- Since the player score is not being set here, the value for the key doesn't matter.
 - To add a key/value pair to a hash table use `(setf (gethash key table) value)`
 
 ## 3. Setting a player's score

--- a/exercises/concept/high-scores/.docs/instructions.md
+++ b/exercises/concept/high-scores/.docs/instructions.md
@@ -16,9 +16,11 @@ To add a player to the table define a function `add-player` which takes two argu
 - the high score table
 - the player's name as a keyword
 
+Set the player's initial score to zero.
+
 ```lisp
-(add-player hash-table :louis) ; => NIL
-(add-player hash-table :lilly) ; => NIL
+(add-player hash-table :louis) ; => 0
+(add-player hash-table :lilly) ; => 0
 ```
 
 ## 3. Setting a player's score


### PR DESCRIPTION
## Summary

For the `add-player` function, I set the player's initial score to `nil`. Reasonably I think due to the examples 
```lisp
(add-player hash-table :louis) ; => NIL
```
and the hint 
> Since the player score is not being set here, the value for the key doesn't matter

Then, the `get-score` hinted implementation
```lisp
(defun get-score (scores name) (gethash name scores 0))
```
fails one test:
```none
FAILED
Test 5
DEFAULT-SCORE (1/1)

CODE RUN
(let ((table (make-high-scores-table)))
  (add-player table :lewis)
  (is (= 0 (get-score table :lewis))))
TEST ERROR
The value
  NIL
is not of type
  NUMBER
when binding SB-KERNEL::X
```

Suggestion: when adding a player, set the initial score to zero.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
