### PR TITLE
fix documentation bugs for Leftovers exercise

### DIFF
--- a/concepts/lambda-list/about.md
+++ b/concepts/lambda-list/about.md
@@ -1,9 +1,9 @@
 # About
 
-In Common Lisp a parameter list (such as for defining a function) is also known as a (lambda list)[lambda-list]. 
+In Common Lisp a parameter list (such as for defining a function) is also known as a [lambda list][lambda-list]. 
 Lambda lists are also used for defining macros and destructuring.
 
-Lambda lists can contain (lambda list keywords)[lambda-list-keyword] such as `&rest`, `&optional`, `&key` and others.
+Lambda lists can contain [lambda list keywords][lambda-list-keyword] such as `&rest`, `&optional`, `&key` and others.
 
 While multiple types of parameters can be combined with other types of parameters (optional and keyword parameters) this can be be problematic and should be done carefully.
 See the section on ["Mixing Different Parameter Types"][pcl-function] in Practical Common Lisp.

--- a/exercises/concept/lillys-lasagna-leftovers/.docs/hints.md
+++ b/exercises/concept/lillys-lasagna-leftovers/.docs/hints.md
@@ -2,29 +2,29 @@
 
 ## 1. Make `preparation-time-in-minutes` easier to use
 
-    - A "rest parameter" will collect all arguments not consumed by other parameters into a list.
-    - A "rest parameter" is designated in the lambda list with the `&rest` lambda list keyword.
-    - The function `length` can be used to get the number of items in a list.
+- A "rest parameter" will collect all arguments not consumed by other parameters into a list.
+- A "rest parameter" is designated in the lambda list with the `&rest` lambda list keyword.
+- The function `length` can be used to get the number of items in a list.
 
 ## 2. Allow changing the expected oven time
 
-    - An optional parameter can be provided or not.
-    - An optional parameter can have a default value.
-    - Optional parameters are designated by the `&optional` lambda list keyword.
+- An optional parameter can be provided or not.
+- An optional parameter can have a default value.
+- Optional parameters are designated by the `&optional` lambda list keyword.
 
 ## 3. Lilly remembers another preferred cooking style
 
-    - A "supplied-p parameter" can be specified with the optional parameter to determine if the caller has provided the parameter.
+- A "supplied-p parameter" can be specified with the optional parameter to determine if the caller has provided the parameter.
 
 ## 4. Splitting the leftovers
 
-    - Keyword parameters are named and are optional.
-    - Keyword parameters are designated with the `&key` lambda list keyword.
+- Keyword parameters are named and are optional.
+- Keyword parameters are designated with the `&key` lambda list keyword.
 
 ## 5. Making assumptions
 
-    - Keyword parameters can have default values.
+- Keyword parameters can have default values.
 
 ## 6. Standard amount of leftovers
 
-    - Keyword parameters can have a "supplied-p parameter" like optional parameters.
+- Keyword parameters can have a "supplied-p parameter" like optional parameters.


### PR DESCRIPTION
## Summary

Fixes broken links and removes indentation from bullet lists.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
