### PR TITLE
Update exercises from problems-specifications

### DIFF
--- a/exercises/practice/crypto-square/.docs/instructions.md
+++ b/exercises/practice/crypto-square/.docs/instructions.md
@@ -4,11 +4,10 @@ Implement the classic method for composing secret messages called a square code.
 
 Given an English text, output the encoded version of that text.
 
-First, the input is normalized: the spaces and punctuation are removed
-from the English text and the message is down-cased.
+First, the input is normalized: the spaces and punctuation are removed from the English text and the message is down-cased.
 
-Then, the normalized characters are broken into rows. These rows can be
-regarded as forming a rectangle when printed with intervening newlines.
+Then, the normalized characters are broken into rows.
+These rows can be regarded as forming a rectangle when printed with intervening newlines.
 
 For example, the sentence
 
@@ -22,18 +21,16 @@ is normalized to:
 "ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots"
 ```
 
-The plaintext should be organized in to a rectangle. The size of the
-rectangle should be decided by the length of the message.
+The plaintext should be organized into a rectangle as square as possible.
+The size of the rectangle should be decided by the length of the message.
 
-If `c` is the number of columns and `r` is the number of rows, then for
-the rectangle `r` x `c` find the smallest possible integer `c` such that:
+If `c` is the number of columns and `r` is the number of rows, then for the rectangle `r` x `c` find the smallest possible integer `c` such that:
 
-- `r * c >= length(message)`,
+- `r * c >= length of message`,
 - and `c >= r`,
 - and `c - r <= 1`.
 
-Our normalized text is 54 characters long, dictating a rectangle with
-`c = 8` and `r = 7`:
+Our normalized text is 54 characters long, dictating a rectangle with `c = 8` and `r = 7`:
 
 ```text
 "ifmanwas"
@@ -45,8 +42,7 @@ Our normalized text is 54 characters long, dictating a rectangle with
 "sroots  "
 ```
 
-The coded message is obtained by reading down the columns going left to
-right.
+The coded message is obtained by reading down the columns going left to right.
 
 The message above is coded as:
 
@@ -54,17 +50,14 @@ The message above is coded as:
 "imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau"
 ```
 
-Output the encoded text in chunks that fill perfect rectangles `(r X c)`,
-with `c` chunks of `r` length, separated by spaces. For phrases that are
-`n` characters short of the perfect rectangle, pad each of the last `n`
-chunks with a single trailing space.
+Output the encoded text in chunks that fill perfect rectangles `(r X c)`, with `c` chunks of `r` length, separated by spaces.
+For phrases that are `n` characters short of the perfect rectangle, pad each of the last `n` chunks with a single trailing space.
 
 ```text
 "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
 ```
 
-Notice that were we to stack these, we could visually decode the
-ciphertext back in to the original message:
+Notice that were we to stack these, we could visually decode the ciphertext back in to the original message:
 
 ```text
 "imtgdvs"

--- a/exercises/practice/meetup/.docs/instructions.md
+++ b/exercises/practice/meetup/.docs/instructions.md
@@ -1,19 +1,51 @@
 # Instructions
 
-In this exercise, you will be given a general description of a meetup date and then asked to find the actual meetup date.
+Recurring monthly meetups are generally scheduled on the given weekday of a given week each month.
+In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
 
-Examples of general descriptions are:
+For example a meetup might be scheduled on the _first Monday_ of every month.
+You might then be asked to find the date that this meetup will happen in January 2018.
+In other words, you need to determine the date of the first Monday of January 2018.
 
-- First Monday of January 2022
-- Third Tuesday of August 2021
-- Teenth Wednesday of May 2022
-- Teenth Sunday of July 2021
-- Last Thursday of November 2021
+Similarly, you might be asked to find:
+
+- the third Tuesday of August 2019 (August 20, 2019)
+- the teenth Wednesday of May 2020 (May 13, 2020)
+- the fourth Sunday of July 2021 (July 25, 2021)
+- the last Thursday of November 2022 (November 24, 2022)
 
 The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
 
 Note that descriptor `teenth` is a made-up word.
-There are exactly seven numbered days in a month that end with "teenth" ("thirteenth" to "nineteenth").
-Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teenth" each month.
 
-For example, if given "First Monday of January 2022", the correct meetup date is January 3, 2022.
+It refers to the seven numbers that end in '-teen' in English: 13, 14, 15, 16, 17, 18, and 19.
+But general descriptions of dates use ordinal numbers, e.g. the _first_ Monday, the _third_ Tuesday.
+
+For the numbers ending in '-teen', that becomes:
+
+- 13th (thirteenth)
+- 14th (fourteenth)
+- 15th (fifteenth)
+- 16th (sixteenth)
+- 17th (seventeenth)
+- 18th (eighteenth)
+- 19th (nineteenth)
+
+So there are seven numbers ending in '-teen'.
+And there are also seven weekdays (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday).
+Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teen" each month.
+
+If asked to find the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
+
+```plaintext
+    August 1953
+Su Mo Tu We Th Fr Sa
+                   1
+ 2  3  4  5  6  7  8
+ 9 10 11 12 13 14 15
+16 17 18 19 20 21 22
+23 24 25 26 27 28 29
+30 31
+```
+
+The Saturday that has a number ending in '-teen' is August 15, 1953.

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -20,6 +20,11 @@ description = "cleans numbers with multiple spaces"
 
 [598d8432-0659-4019-a78b-1c6a73691d21]
 description = "invalid when 9 digits"
+include = false
+
+[2de74156-f646-42b5-8638-0ef1d8b58bc2]
+description = "invalid when 9 digits"
+reimplements = "598d8432-0659-4019-a78b-1c6a73691d21"
 
 [57061c72-07b5-431f-9766-d97da7c4399d]
 description = "invalid when 11 digits does not start with a 1"
@@ -32,6 +37,11 @@ description = "valid when 11 digits and starting with 1 even with punctuation"
 
 [c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
 description = "invalid when more than 11 digits"
+include = false
+
+[4a1509b7-8953-4eec-981b-c483358ff531]
+description = "invalid when more than 11 digits"
+reimplements = "c6a5f007-895a-4fc5-90bc-a7e70f9b5cad"
 
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"

--- a/exercises/practice/say/.docs/instructions.md
+++ b/exercises/practice/say/.docs/instructions.md
@@ -48,13 +48,3 @@ Put it all together to get nothing but plain English.
 `12345` should give `twelve thousand three hundred forty-five`.
 
 The program must also report any values that are out of range.
-
-### Extensions
-
-Use _and_ (correctly) when spelling out the number in English:
-
-- 14 becomes "fourteen".
-- 100 becomes "one hundred".
-- 120 becomes "one hundred and twenty".
-- 1002 becomes "one thousand and two".
-- 1323 becomes "one thousand three hundred and twenty-three".

--- a/exercises/practice/space-age/.docs/instructions.md
+++ b/exercises/practice/space-age/.docs/instructions.md
@@ -16,4 +16,10 @@ be able to say that they're 31.69 Earth-years old.
 
 If you're wondering why Pluto didn't make the cut, go watch [this YouTube video][pluto-video].
 
+Note: The actual length of one complete orbit of the Earth around the sun is closer to 365.256 days (1 sidereal year).
+The Gregorian calendar has, on average, 365.2425 days.
+While not entirely accurate, 365.25 is the value used in this exercise.
+See [Year on Wikipedia][year] for more ways to measure a year.
+
 [pluto-video]: https://www.youtube.com/watch?v=Z_2gbGXzFbs
+[year]: https://en.wikipedia.org/wiki/Year#Summary

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -13,7 +13,7 @@
       ".meta/example.lisp"
     ]
   },
-  "blurb": " Given the size, return a square matrix of numbers in spiral order.",
+  "blurb": "Given the size, return a square matrix of numbers in spiral order.",
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"
 }


### PR DESCRIPTION
## Summary

This change fixes all the sync problems noted in #697. There is an additional problem at the current time with `palindrome-products` which is *not* handled by this PR. It will be dealt with separately.

Of special note is that while the test list for `phone-numbers` is updated there are no new or changed tests. This is because the changes to the tests from the `problems-specifications` repository is in the error message returned in those test cases. However the tests in this track do not expect error messages so the tests themselves did not need any changes.

Fixes #697.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green