### PR TITLE
chore(exercise): update palindrome-products tests

### DIFF
--- a/exercises/practice/palindrome-products/.meta/tests.toml
+++ b/exercises/practice/palindrome-products/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [5cff78fe-cf02-459d-85c2-ce584679f887]
 description = "find the smallest palindrome from single digit factors"
@@ -37,3 +44,6 @@ description = "error result for smallest if min is more than max"
 
 [eeeb5bff-3f47-4b1e-892f-05829277bd74]
 description = "error result for largest if min is more than max"
+
+[16481711-26c4-42e0-9180-e2e4e8b29c23]
+description = "smallest product does not use the smallest factor"

--- a/exercises/practice/palindrome-products/palindrome-products-test.lisp
+++ b/exercises/practice/palindrome-products/palindrome-products-test.lisp
@@ -105,6 +105,14 @@
           (max-factor 1))
       (is (eql NIL (palindrome-products:largest min-factor max-factor)))))
 
+(test smallest-product-does-not-use-the-smallest-factor
+    (let ((min-factor 3215)
+          (max-factor 4000)
+          (palindrome 10988901)
+          (factors '((3297 3333))))
+      (is (multiple-value-bind (p f) (palindrome-products:smallest min-factor max-factor)
+                               (and (eql p palindrome) (equal f factors))))))
+
 (defun run-tests (&optional (test-or-suite 'palindrome-products-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))


### PR DESCRIPTION
This brings the exercise in line with the latest version from the problem-specifications repository.

@verdammelt mentioned that our example implementation wasn't passing tests, but it seems to work for me? Perhaps I've implemented the test incorrectly? This PR definitely needs a sanity-check!

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
