### PR TITLE
Fix configlet-sync: add missing GitHub token

### DIFF
--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -15,7 +15,12 @@ jobs:
 
     - name: Fetch configlet
       uses: exercism/github-actions/configlet-ci@main
-        
+      # GITHUB_TOKEN is not set when we run the fetch script, because we're in
+      # a composite action. Set GH_TOKEN so that `gh release download` can
+      # make authenticated requests (it fails otherwise).
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Configlet Sync
       id: sync
       shell: bash {0}


### PR DESCRIPTION
The configlet-ci action switched to using the gh cli command and needs to have `GH_TOKEN` set to work now.

This sets the token in the same way as upstream does it at https://github.com/exercism/github-actions/blob/a3f83169a9218d28cae3c04d70522f0519d92d46/.github/workflows/configlet.yml#L29-L33

Previous error was:

> The GH_TOKEN environment variable is not set

See https://github.com/exercism/github-actions/pull/107 for more context

## Summary

As discussed [in the forum](https://forum.exercism.org/t/failing-configlet-sync-github-action/3278/2) this fixes the broken configlet-sync workflow.
This is the corresponding PR for the Emacs Lisp track: https://github.com/exercism/emacs-lisp/pull/271

## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
