### PR TITLE
configlet-sync: don't run workflow on forks

### DIFF
--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   configlet:
+    if: github.repository_owner == 'exercism' # Stops this job from running on forks
     timeout-minutes: 30
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Running this action doesn't really makes sense for forks and leads to annoying notifications for people with forks.

## Summary

This is another change I proposed for the Emacs Lisp track, maybe you like it as well.
Reference: https://github.com/exercism/emacs-lisp/pull/272


## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
