### PR TITLE
Update links.json

### DIFF
--- a/concepts/arrays/links.json
+++ b/concepts/arrays/links.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/13_aa.htm",
-    "description": "Introduction to arrays from the specification"
+    "url": "http://www.lispworks.com/documentation/HyperSpec/Body/c_arrays.htm",
+    "description": "The Arrays Dictionary from the specification"
   }
 ]


### PR DESCRIPTION
## Summary

This seems like a copy and paste error from the characters
1. The existing link was pointing to the introduction of characters from the spec, nothing to do with arrays
2. There is no "introduction to arrays" in the spec.  The closest useful thing I can find is "The Arrays Dictionary" from the spec.

## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
