### PR TITLE
fix typo in "About Lists" section

### DIFF
--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -6,7 +6,7 @@ Each `car` is an element of the list and every `cdr` is a either the next cons c
 
 A list which terminates with the empty list is called a "proper list".
 
-A list which terminates with an atom that is not th empty list is called a "dotted list" (based upon how it is printed: `(cons 'a 'b) ;=> (a . b)`).
+A list which terminates with an atom that is not the empty list is called a "dotted list" (based upon how it is printed: `(cons 'a 'b) ;=> (a . b)`).
 
 A list can also be circular if some cons cell in the list `cdr` of a later cons cell.
 For example: `(let ((x (list 1))) (setf (cdr x) x) (write x :stream t :circle t) :done)`.


### PR DESCRIPTION
## Summary

Fix typo in sentence "...that is not th empty list...", which should be "...that is not the empty list...".


## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
