### PR TITLE
Fix typos in a few sections

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -63,7 +63,7 @@ An element can also be accessed with `row-major-aref` which takes a single integ
 
 ## Predicate
 
-To deterine if an object is an array one can use `arrayp`.
+To determine if an object is an array one can use `arrayp`.
 
 ```lisp
 (arrayp #(1 2 3))            ; => T

--- a/concepts/equality/about.md
+++ b/concepts/equality/about.md
@@ -53,7 +53,7 @@ This is done recursively.
 - strings and bit vectors are [`equal`][hyper-equal] if their elements are `eql`
 - arrays of other types are compared as if with [`eq`][hyper-eq]
 - pathnames are [`equal`][hyper-equal] if they are functionality equivalent.
-(There is room for implementation dependendant behavior here with regards to case sensitivity of the strings which make up the components of the pathnames.)
+(There is room for implementation dependent behavior here with regards to case sensitivity of the strings which make up the components of the pathnames.)
 - objects of any other type are compared as if with [`eq`][hyper-eq]
 
 ```lisp
@@ -70,7 +70,7 @@ The fourth and most loose level of equality is checked with [`equalp`][hyper-equ
 The how the checking is done depends upon the types:
 
 - if the two objects are [`equalp`][hyper-equalp] then they are [`equalp`][hyper-equalp]
-- numbers are [`equalp`][hyper-equalp] if they have the same vaule even if they are not of the same type
+- numbers are [`equalp`][hyper-equalp] if they have the same value even if they are not of the same type
 - characters and strings are compared case-insensitively
 - conses are [`equalp`][hyper-equalp] if their elements are [`equalp`][hyper-equalp].
 This is done recursively.

--- a/exercises/concept/character-study/.docs/hints.md
+++ b/exercises/concept/character-study/.docs/hints.md
@@ -20,7 +20,7 @@
 ## 4. Determine the "type" of a character
 
 - Common Lisp has a predicate function `alpha-char-p` to tell if a character is an alphabetic character.
-- Common Lisp has a preidicate function `digit-char-p` to tell if a character is a numeric character.
+- Common Lisp has a predicate function `digit-char-p` to tell if a character is a numeric character.
 - You can use `char=` to tell if two characters are equal.
 - The space character is written #\Space in Common Lisp.
 - The newline character is written #\Newline in Common Lisp.

--- a/exercises/concept/high-scores/.docs/introduction.md
+++ b/exercises/concept/high-scores/.docs/introduction.md
@@ -24,13 +24,13 @@ To get a value by a key from the hash table you use the `gethash` function:
                    ;    T
 ```
 
-`gethash` returns [multiple values][concept-multiple-values] which will be explained in another concept.
+`gethash` returns [multiple values][concepts-multiple-values] which will be explained in another concept.
 
 ### Inserting values
 
 To insert a value into a hash table you use `setf` with `gethash` like this:
 
-`(setf (gethash :foo *hash-table*) :bar) ; => :bar`
+`(setf (gethash :foo *hash-table*) :bar) : => :bar`
 
 This will modify the value for the key `:foo` in the hash table `*hash-table*` to be `:bar`.
 It returns the value.

--- a/exercises/concept/leslies-lists/.docs/instructions.md
+++ b/exercises/concept/leslies-lists/.docs/instructions.md
@@ -14,7 +14,7 @@ First thing is that Leslie needs to create a empty list. A function called `new-
 (new-list) ; => ()
 ```
 
-Oh no... Leslie has a few things in mind already, so they need a function that takes three items (luckily Leslie only creates a list of three items. Nothing more, nothing less!) and creates a new shopping list with those things. Write a function, `list-of-things` which takes three items and retunrs a list of them.
+Oh no... Leslie has a few things in mind already, so they need a function that takes three items (luckily Leslie only creates a list of three items. Nothing more, nothing less!) and creates a new shopping list with those things. Write a function, `list-of-things` which takes three items and returns a list of them.
 
 ```lisp
 (list-of-things 'bread 'milk 'butter) ; => '(bread milk butter)

--- a/exercises/concept/lucys-magnificent-mapper/.docs/hints.md
+++ b/exercises/concept/lucys-magnificent-mapper/.docs/hints.md
@@ -8,5 +8,5 @@
 ## 2. Only the best
 
 - Filtering is the correct process to remove one or more items from a sequence, resulting in a new sequence.
-- `remove` can remove values from a sequence which are equal to a specfic item.
+- `remove` can remove values from a sequence which are equal to a specific item.
 - `remove-if` can remove values for which a predicate function evaluates to a true value.

--- a/reference/exercise-concepts/roman-numerals.md
+++ b/reference/exercise-concepts/roman-numerals.md
@@ -1,6 +1,6 @@
 # Concepts of Roman Numerals
 
-This one is a bit of 'cheat' of an exericse - but the concept is real.
+This one is a bit of 'cheat' of an exercise - but the concept is real.
 
 ## Concepts
 


### PR DESCRIPTION
## Summary

While doing the Common Lisp track for the Summer of Sexps, I noticed a few typos here and there and thought I'd just fix them as I went along. This is by no mean an extensive proofreading, just a few minor things I noticed.

- Arrays
- Equality
- Leslie's list
- Character study
- Roman numerals


## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
