### PR TITLE
Remove duplicate test

### DIFF
--- a/exercises/practice/largest-series-product/largest-series-product-test.lisp
+++ b/exercises/practice/largest-series-product/largest-series-product-test.lisp
@@ -80,11 +80,6 @@
           (span -1))
      (is (eql NIL (largest-series-product:largest-product digits span)))))
 
-(test rejects-negative-span
-    (let ((digits "12345")
-          (span -1))
-     (is (eql NIL (largest-series-product:largest-product digits span)))))
-
 (defun run-tests (&optional (test-or-suite 'largest-series-product-suite))
   "Provides human readable results of test run. Default to entire suite."
   (run! test-or-suite))


### PR DESCRIPTION
Looking at the problem-specification repository it seems that the
latter test is a reimplementation of the previous test due to a change
in the error message of the canonical data. (In this track we are not
using the error messsage, simply evaluating to NIL.)

-------