### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/config-checker.yml
+++ b/.github/workflows/config-checker.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   config-check:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: clfoundation/sbcl

--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -9,7 +9,7 @@ jobs:
   configlet:
     if: github.repository_owner == 'exercism' # Stops this job from running on forks
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-exercises.yml
+++ b/.github/workflows/test-exercises.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   run-tests:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: clfoundation/sbcl


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.