### PR TITLE
Add blank name test for two-fer

### DIFF
--- a/exercises/practice/two-fer/two-fer-test.lisp
+++ b/exercises/practice/two-fer/two-fer-test.lisp
@@ -24,6 +24,8 @@
 (test another-name-given
  (is (equal "One for Bob, one for me." (two-fer:twofer "Bob"))))
 
+(test blank-name-given (is (equal "One for you, one for me." (two-fer:twofer ""))))
+
 (test no-name-given (is (equal "One for you, one for me." (two-fer:twofer))))
 
 (defun run-tests (&optional (test-or-suite 'two-fer-suite))


### PR DESCRIPTION
## Summary

Within the two-fer tests, there is a test that will default the name parameter to nil, which will cause the output to be "One for , one for me." With the user intended to check for nil to ensure that "you" is substituted.

In the same pattern, a test that provides a blank input would also require the user to ensure that the output is not "One for , one for me.", with the "you" substituted.

This is a useful test for beginner developers as the usual first mitigation for a null is to default the value to empty (in this case, blank), and is a potential input to this function that the user should defend against.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
