### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/config-checker.yml
+++ b/.github/workflows/config-checker.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Check Config
-        uses: ./.github/actions/perform-system@{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}
+        uses: ./.github/actions/perform-system
         with:
           system: config-checker
           operation: test-system

--- a/.github/workflows/config-checker.yml
+++ b/.github/workflows/config-checker.yml
@@ -12,10 +12,10 @@ jobs:
         
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Check Config
-        uses: ./.github/actions/perform-system
+        uses: ./.github/actions/perform-system@{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}
         with:
           system: config-checker
           operation: test-system

--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
     - name: Fetch configlet
       uses: exercism/github-actions/configlet-ci@main

--- a/.github/workflows/test-exercises.yml
+++ b/.github/workflows/test-exercises.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Run Tests
-        uses: ./.github/actions/perform-system@{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}
+        uses: ./.github/actions/perform-system
         with:
           system: test-exercises
           operation: test-system

--- a/.github/workflows/test-exercises.yml
+++ b/.github/workflows/test-exercises.yml
@@ -12,10 +12,10 @@ jobs:
         
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Run Tests
-        uses: ./.github/actions/perform-system
+        uses: ./.github/actions/perform-system@{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}
         with:
           system: test-exercises
           operation: test-system


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.