### PR TITLE
Equality concept write-up was wrong about equal and arrays

### DIFF
--- a/concepts/equality/introduction.md
+++ b/concepts/equality/introduction.md
@@ -29,12 +29,12 @@ A quick set of definitions (leaving out a few details) are as follows:
 (eql #\a #\A) ; => NIL
 ```
 
-- `equal`: defines equality as meaning: two lists are `equal` if each element is also `equal`; two arrays are `equal` if each element is `eq`; two strings are `equal` if each element is `eql`; everything else is `equal` if they are `eql`.
+- `equal`: defines equality as meaning: two lists are `equal` if each element is also `equal`; two strings are `equal` if each element is `eql`; two arrays are `equal` if they are `eq`; everything else is `equal` if they are `eql`.
   _e.g._:
 
 ```lisp
 (equal (list 1 2) (list 1 2)) ; => T
-(equal #(1 2) #(1 2))         ; => T
+(equal #(1 2) #(1 2))         ; => NIL
 (equal "foo" "foo")           ; => T
 ```
 

--- a/exercises/concept/key-comparison/.docs/introduction.md
+++ b/exercises/concept/key-comparison/.docs/introduction.md
@@ -31,12 +31,12 @@ A quick set of definitions (leaving out a few details) are as follows:
 (eql #\a #\A) ; => NIL
 ```
 
-- `equal`: defines equality as meaning: two lists are `equal` if each element is also `equal`; two arrays are `equal` if each element is `eq`; two strings are `equal` if each element is `eql`; everything else is `equal` if they are `eql`.
+- `equal`: defines equality as meaning: two lists are `equal` if each element is also `equal`; two strings are `equal` if each element is `eql`; two arrays are `equal` if they are `eq`; everything else is `equal` if they are `eql`.
   _e.g._:
 
 ```lisp
 (equal (list 1 2) (list 1 2)) ; => T
-(equal #(1 2) #(1 2))         ; => T
+(equal #(1 2) #(1 2))         ; => NIL
 (equal "foo" "foo")           ; => T
 ```
 


### PR DESCRIPTION
Arrays are only equal if the arrays are eq. (Except for
strings which are already mentioned; and vectors which will need their
own concept)

Fixes #696