### PR TITLE
Update configlet GHA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Exercism Common Lisp Track
-
-[![Configlet Lint Status](https://github.com/exercism/common-lisp/workflows/Configlet%20CI/badge.svg)](https://github.com/exercism/common-lisp/workflows/Configlet%20CI/badge.svg)
+[![Configlet](https://github.com/exercism/common-lisp/actions/workflows/configlet.yml/badge.svg)](https://github.com/exercism/common-lisp/actions/workflows/configlet.yml)
 [![Config Check Status](https://github.com/exercism/common-lisp/workflows/Config%20Check/badge.svg)](https://github.com/exercism/common-lisp/workflows/Config%20Check/badge.svg)
 [![Exercise Test Status](https://github.com/exercism/common-lisp/workflows/Test%20Exercises/badge.svg)](https://github.com/exercism/common-lisp/workflows/Test%20Exercises/badge.svg)
 


### PR DESCRIPTION
## Summary

I noticed the configlet GHA badge was broken on the repo's README. I regenerated the markdown for the current configlet action.

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
