### PR TITLE
Remove unnecessary comma removal, simplify boundary checking

### DIFF
--- a/exercises/practice/say/.meta/example.lisp
+++ b/exercises/practice/say/.meta/example.lisp
@@ -5,5 +5,5 @@
 (in-package :say)
 
 (defun say (number)
-  (unless (or (minusp number) (>= number (expt 10 12)))
-    (remove #\, (format nil "~R" number))))
+  (when (< -1 number (expt 10 12))
+    (format nil "~r" number)))


### PR DESCRIPTION
Some older version of SBCL had commas in the result of `~R`. Since
that no longer seems to be happening we can simplify the code.