### PR TITLE
[concept/pal-picker] fix typo in instructions.md

### DIFF
--- a/exercises/concept/pal-picker/.docs/instructions.md
+++ b/exercises/concept/pal-picker/.docs/instructions.md
@@ -39,7 +39,7 @@ Now that Ludwig has a new friend, they'll need a place to stay! Can you help
 Ludwig select the right size bed / tank / cage for their pet?
 
 Here, Ludwig needs a function called `habitat-fitter` for selecting the proper
-habitat size (a keyword) from their pet's weight in kilograms (a integer).
+habitat size (a keyword) from their pet's weight in kilograms (an integer).
 
 The habitats needed by each size pet are:
 


### PR DESCRIPTION
## Summary

I found a typo in one of the exercises. 


## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
