### PR TITLE
Clarify array equality

### DIFF
--- a/exercises/concept/key-comparison/.docs/instructions.md
+++ b/exercises/concept/key-comparison/.docs/instructions.md
@@ -112,16 +112,21 @@ because even with an equality predicate that will look inside of a cons, it may 
 
 ## 6. The maze of arrays
 
-This maze is simpler with only two rooms. The first needs a key that checks if the arrays contain the equal contents. The second needs a key that is more flexible about checking equality of numbers.
+This maze is simpler with only two rooms. 
+The first needs a key that checks if the arrays are the same arrays. 
+The second needs a key that will check the contents of the arrays.
 
 For example:
 
 ```lisp
 a                        ; => #[13 23]
-b                        ; => #[13 23.0]
+b                        ; => #[13 23]
+c                        ; => #[13 23.0]
 
 (key-arrays a b)         ; => NIL
+(key-arrays a c)         ; => NIL
 (key-arrays-loosely a b) ; => T
+(key-arrays-loosely a c) ; => T
 ```
 
-because a permissive equality predicate will not consider numeric type when comparing the contents of an array.
+because only very permissive equality checkers will check that if the contents of the array are equal.

--- a/exercises/concept/key-comparison/key-comparison-test.lisp
+++ b/exercises/concept/key-comparison/key-comparison-test.lisp
@@ -82,7 +82,7 @@
          finally (return 'room-explodes))))
 
 (defparameter +an-array+ #(1 2 3))
-(defparameter +a-similar-but-different-array+ #(1 2 3))
+(defparameter +a-similar-but-different-array+ #(1 2.0 3))
 (defparameter +a-different-array+ #(1 2 4))
 
 (defparameter +rooms+


### PR DESCRIPTION
The test data and instructions could have led to confusion.

The previous instructions and code could lead someone to believe that an equality predicate other than `equalp` *could* work for the "loosely" function. However even with the previous test data that could not be since all equality predicates but `equalp` only consider arrays equal if they are `eq`. Only `equalp` checks the contents of the array for equality.

The mention of numeric type (and then not showing it in the test) was an unintentional red herring.

Both the test data and the instructions have been changed to (hopefully) make things clearer.

Fixes #798


[no important files changed]