### PR TITLE
Fix typo in Introduction section

### DIFF
--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Given that the name of the language is Lisp which stands of _LISt Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
+Given that the name of the language is Lisp which stands of _LIST Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
 
 While Common Lisp has other data structures as well as lists, lists are still heavily used.
 

--- a/exercises/concept/leslies-lists/.docs/introduction.md
+++ b/exercises/concept/leslies-lists/.docs/introduction.md
@@ -2,7 +2,7 @@
 
 ## Lists
 
-Given that the name of the language is Lisp which stands of _LISt Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
+Given that the name of the language is Lisp which stands of _LIST Processing_ one might assume that the language has facilities for handling lists of items, and you'd be correct!
 
 While Common Lisp has other data structures as well as lists, lists are still heavily used.
 


### PR DESCRIPTION
Fix typo: "LISt Processing" to "LIST Processing" in the introduction section

## Summary

(Explain what this change is attempting to accomplish)
Typo fix in the introduction section from "LISt Processing" to "LIST Processing".

## Checklist
- [x] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
