### PR TITLE
Sync docs and tests

### DIFF
--- a/exercises/practice/affine-cipher/.docs/instructions.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.md
@@ -20,7 +20,7 @@ Where:
 
 - `i` is the letter's index from `0` to the length of the alphabet - 1.
 - `m` is the length of the alphabet.
-  For the Roman alphabet `m` is `26`.
+  For the Latin alphabet `m` is `26`.
 - `a` and `b` are integers which make up the encryption key.
 
 Values `a` and `m` must be _coprime_ (or, _relatively prime_) for automatic decryption to succeed, i.e., they have number `1` as their only common factor (more information can be found in the [Wikipedia article about coprime integers][coprime-integers]).

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -1,11 +1,16 @@
 # Instructions
 
-Take a nested list and return a single flattened list with all values except nil/null.
+Take a nested array of any depth and return a fully flattened array.
 
-The challenge is to take an arbitrarily-deep nested list-like structure and produce a flattened structure without any nil/null values.
+Note that some language tracks may include null-like values in the input array, and the way these values are represented varies by track.
+Such values should be excluded from the flattened array.
 
-For example:
+Additionally, the input may be of a different data type and contain different types, depending on the track.
 
-input: [1,[2,3,null,4],[null],5]
+Check the test suite for details.
 
-output: [1,2,3,4,5]
+## Example
+
+input: `[1, [2, 6, null], [[null, [4]], 5]]`
+
+output: `[1, 2, 6, 4, 5]`

--- a/exercises/practice/flatten-array/.docs/introduction.md
+++ b/exercises/practice/flatten-array/.docs/introduction.md
@@ -1,0 +1,7 @@
+# Introduction
+
+A shipment of emergency supplies has arrived, but there's a problem.
+To protect from damage, the items — flashlights, first-aid kits, blankets — are packed inside boxes, and some of those boxes are nested several layers deep inside other boxes!
+
+To be prepared for an emergency, everything must be easily accessible in one box.
+Can you unpack all the supplies and place them into a single box, so they're ready when needed most?

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -34,3 +34,15 @@ description = "6 level nest list with null values"
 
 [85721643-705a-4150-93ab-7ae398e2942d]
 description = "all values in nested list are null"
+
+[bc72da10-5f55-4ada-baf3-50e4da02ec8e]
+description = "consecutive null values at the front of the array are omitted from the final result"
+
+[6991836d-0d9b-4703-80a0-3f1f23eb5981]
+description = "consecutive null values in the middle of the array are omitted from the final result"
+
+[dc90a09c-5376-449c-a7b3-c2d20d540069]
+description = "6 level nested array with null values"
+
+[51f5d9af-8f7f-4fb5-a156-69e8282cb275]
+description = "all values in nested list are null"

--- a/exercises/practice/grains/.docs/instructions.md
+++ b/exercises/practice/grains/.docs/instructions.md
@@ -1,15 +1,11 @@
 # Instructions
 
-Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.
+Calculate the number of grains of wheat on a chessboard.
 
-There once was a wise servant who saved the life of a prince.
-The king promised to pay whatever the servant could dream up.
-Knowing that the king loved chess, the servant told the king he would like to have grains of wheat.
-One grain on the first square of a chess board, with the number of grains doubling on each successive square.
+A chessboard has 64 squares.
+Square 1 has one grain, square 2 has two grains, square 3 has four grains, and so on, doubling each time.
 
-There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
+Write code that calculates:
 
-Write code that shows:
-
-- how many grains were on a given square, and
+- the number of grains on a given square
 - the total number of grains on the chessboard

--- a/exercises/practice/grains/.docs/introduction.md
+++ b/exercises/practice/grains/.docs/introduction.md
@@ -1,0 +1,6 @@
+# Introduction
+
+There once was a wise servant who saved the life of a prince.
+The king promised to pay whatever the servant could dream up.
+Knowing that the king loved chess, the servant told the king he would like to have grains of wheat.
+One grain on the first square of a chessboard, with the number of grains doubling on each successive square.

--- a/exercises/practice/saddle-points/.docs/instructions.md
+++ b/exercises/practice/saddle-points/.docs/instructions.md
@@ -13,11 +13,12 @@ Or it might have one, or even several.
 Here is a grid that has exactly one candidate tree.
 
 ```text
-    1  2  3  4
-  |-----------
-1 | 9  8  7  8
-2 | 5  3  2  4  <--- potential tree house at row 2, column 1, for tree with height 5
-3 | 6  6  7  1
+      ↓
+      1  2  3  4
+    |-----------
+  1 | 9  8  7  8
+→ 2 |[5] 3  2  4
+  3 | 6  6  7  1
 ```
 
 - Row 2 has values 5, 3, 2, and 4. The largest value is 5.

--- a/exercises/practice/sieve/.docs/instructions.md
+++ b/exercises/practice/sieve/.docs/instructions.md
@@ -6,37 +6,96 @@ A prime number is a number larger than 1 that is only divisible by 1 and itself.
 For example, 2, 3, 5, 7, 11, and 13 are prime numbers.
 By contrast, 6 is _not_ a prime number as it not only divisible by 1 and itself, but also by 2 and 3.
 
-To use the Sieve of Eratosthenes, you first create a list of all the numbers between 2 and your given number.
-Then you repeat the following steps:
+To use the Sieve of Eratosthenes, first, write out all the numbers from 2 up to and including your given number.
+Then, follow these steps:
 
-1. Find the next unmarked number in your list (skipping over marked numbers).
+1. Find the next unmarked number (skipping over marked numbers).
    This is a prime number.
 2. Mark all the multiples of that prime number as **not** prime.
 
-You keep repeating these steps until you've gone through every number in your list.
+Repeat the steps until you've gone through every number.
 At the end, all the unmarked numbers are prime.
 
 ~~~~exercism/note
-The tests don't check that you've implemented the algorithm, only that you've come up with the correct list of primes.
-To check you are implementing the Sieve correctly, a good first test is to check that you do not use division or remainder operations.
+The Sieve of Eratosthenes marks off multiples of each prime using addition (repeatedly adding the prime) or multiplication (directly computing its multiples), rather than checking each number for divisibility.
+
+The tests don't check that you've implemented the algorithm, only that you've come up with the correct primes.
 ~~~~
 
 ## Example
 
 Let's say you're finding the primes less than or equal to 10.
 
-- List out 2, 3, 4, 5, 6, 7, 8, 9, 10, leaving them all unmarked.
+- Write out 2, 3, 4, 5, 6, 7, 8, 9, 10, leaving them all unmarked.
+
+  ```text
+  2 3 4 5 6 7 8 9 10
+  ```
+
 - 2 is unmarked and is therefore a prime.
   Mark 4, 6, 8 and 10 as "not prime".
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] 9 [10]
+  ↑
+  ```
+
 - 3 is unmarked and is therefore a prime.
   Mark 6 and 9 as not prime _(marking 6 is optional - as it's already been marked)_.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+    ↑
+  ```
+
 - 4 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+       ↑
+  ```
+
 - 5 is unmarked and is therefore a prime.
   Mark 10 as not prime _(optional - as it's already been marked)_.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+          ↑
+  ```
+
 - 6 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+             ↑
+  ```
+
 - 7 is unmarked and is therefore a prime.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                ↑
+  ```
+
 - 8 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                   ↑
+  ```
+
 - 9 is marked as "not prime", so we skip over it.
+
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                       ↑
+  ```
+
 - 10 is marked as "not prime", so we stop as there are no more numbers to check.
 
-You've examined all numbers and found 2, 3, 5, and 7 are still unmarked, which means they're the primes less than or equal to 10.
+  ```text
+  2 3 [4] 5 [6] 7 [8] [9] [10]
+                           ↑
+  ```
+
+You've examined all the numbers and found that 2, 3, 5, and 7 are still unmarked, meaning they're the primes less than or equal to 10.


### PR DESCRIPTION
Note that flatten-array tests file was updated - but the tests themselves remained the same. Also note that file the name of the exercise is `flatten-*array*` the track has previously chosen to implement with lists rather than vectors/arrays. This discrepancy was not addressed in this PR.


Fixes #851 