### PR TITLE
Fix bottle-song config file

### DIFF
--- a/exercises/practice/bottle-song/.meta/config.json
+++ b/exercises/practice/bottle-song/.meta/config.json
@@ -4,13 +4,13 @@
   ],
   "files": {
     "solution": [
-      "./bottle-song.lisp"
+      "bottle-song.lisp"
     ],
     "test": [
-      "./bottle-song-test.lisp"
+      "bottle-song-test.lisp"
     ],
     "example": [
-      "./.meta/example.lisp"
+      ".meta/example.lisp"
     ]
   },
   "blurb": "Produce the lyrics to the popular children's repetitive song: Ten Green Bottles.",


### PR DESCRIPTION
Config file generated with `configlet` sets paths to start with `"./"`
which appears to cause problems in the UI.