### PR TITLE
Add `reverse-string` exercise

### DIFF
--- a/exercises/practice/reverse-string/.docs/instructions.md
+++ b/exercises/practice/reverse-string/.docs/instructions.md
@@ -1,0 +1,5 @@
+# Instructions
+
+Reversing strings (reading them from right to left, rather than from left to right) is a surprisingly common task in programming.
+
+For example, in bioinformatics, reversing the sequence of DNA or RNA strings is often important for various analyses, such as finding complementary strands or identifying palindromic sequences that have biological significance.

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,0 +1,15 @@
+{
+   "title": "Reverse String",
+   "blurb": "Reverse a given string.",
+   "source": "Introductory challenge to reverse an input string",
+   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb",
+   "deep_dive_youtube_id": "biGAfK6OElE",
+   "deep_dive_blurb": "Explore 14 different ways to reverse a string, exploring a range of topics including Unicode Codepoints, Graphemes, Stack vs Heap allocations, and pointers. Kick back and enjoy 45mins of learning with Jeremy and Erik.",
+   "files": {
+      "test": ["reverse-string-test.lisp"],
+      "solution": ["reverse-string.lisp"],
+      "example": [".meta/example.lisp"]
+   },
+   "authors": ["wsgac"],
+   "contributors": []
+}

--- a/exercises/practice/reverse-string/.meta/example.lisp
+++ b/exercises/practice/reverse-string/.meta/example.lisp
@@ -1,0 +1,21 @@
+(defpackage :reverse-string
+  (:use :cl)
+  (:export :reverse-string))
+
+(in-package :reverse-string)
+
+(defun reverse-string (value)
+  "Reverse the string `value`. Handle wide characters with care."
+  (labels ((combining-char-p (c)
+             (eql :nsm (sb-unicode:bidi-class c)))
+           (%reverse (chars group acc)
+             (cond ((endp chars)
+                    (coerce (append (nreverse group) acc) 'string))
+                   ((combining-char-p (first chars))
+                    (%reverse (rest chars)
+                              (cons (first chars) group)
+                              acc))
+                   (t (%reverse (rest chars)
+                                (list (first chars))
+                                (append (nreverse group) acc))))))
+    (%reverse (coerce value 'list) nil nil)))

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,30 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"

--- a/exercises/practice/reverse-string/reverse-string-test.lisp
+++ b/exercises/practice/reverse-string/reverse-string-test.lisp
@@ -1,0 +1,56 @@
+;; Ensures that reverse-string.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "reverse-string")
+  (quicklisp-client:quickload :fiveam))
+
+;; Defines the testing package with symbols from reverse-string and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :reverse-string-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
+
+;; Enter the testing package
+(in-package :reverse-string-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* reverse-string-suite)
+
+(test an-empty-string
+    (let ((value ""))
+      (is (string= "" (reverse-string:reverse-string value)))))
+
+(test a-word
+    (let ((value "robot"))
+      (is (string= "tobor" (reverse-string:reverse-string value)))))
+
+(test a-capitalized-word
+    (let ((value "Ramen"))
+      (is (string= "nemaR" (reverse-string:reverse-string value)))))
+
+(test a-sentence-with-punctuation
+    (let ((value "I'm hungry!"))
+      (is (string= "!yrgnuh m'I" (reverse-string:reverse-string value)))))
+
+(test a-palindrome
+    (let ((value "racecar"))
+      (is (string= "racecar" (reverse-string:reverse-string value)))))
+
+(test an-even-sized-word
+    (let ((value "drawer"))
+      (is (string= "reward" (reverse-string:reverse-string value)))))
+
+(test wide-characters
+    (let ((value "子猫"))
+      (is (string= "猫子" (reverse-string:reverse-string value)))))
+
+(test grapheme-cluster-with-pre-combined-form
+    (let ((value "Würstchenstand"))
+      (is (string= "dnatsnehctsrüW" (reverse-string:reverse-string value)))))
+
+(test grapheme-clusters
+    (let ((value "ผู้เขียนโปรแกรม"))
+      (is (string= "มรกแรปโนยขีเผู้" (reverse-string:reverse-string value)))))
+
+(defun run-tests (&optional (test-or-suite 'reverse-string-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/reverse-string/reverse-string.lisp
+++ b/exercises/practice/reverse-string/reverse-string.lisp
@@ -1,0 +1,8 @@
+(defpackage :reverse-string
+  (:use :cl)
+  (:export :reverse-string))
+
+(in-package :reverse-string)
+
+(defun reverse-string (value)
+  "Reverse the string `value`. Handle wide characters with care.")


### PR DESCRIPTION
## Summary

I noticed the absence of this exercise from the CL track. I found it instructive and kinda tricky when dealing with the combining characters in strings.


## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [x] CI is green
