### PR TITLE
Add `resistor-color`

### DIFF
--- a/config.json
+++ b/config.json
@@ -1313,6 +1313,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "resistor-color",
+        "name": "Resistor Color",
+        "uuid": "59c87423-c430-4e46-9790-bef60c9c62eb",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
       }
     ],
     "foregone": [

--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -1,0 +1,39 @@
+# Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+
+These colors are encoded as follows:
+
+- black: 0
+- brown: 1
+- red: 2
+- orange: 3
+- yellow: 4
+- green: 5
+- blue: 6
+- violet: 7
+- grey: 8
+- white: 9
+
+The goal of this exercise is to create a way:
+
+- to look up the numerical value associated with a particular color band
+- to list the different band colors
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array:
+Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article][e-color-code].
+
+[e-color-code]: https://en.wikipedia.org/wiki/Electronic_color_code

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "resistor-color.lisp"
+    ],
+    "test": [
+      "resistor-color-test.lisp"
+    ],
+    "example": [
+      ".meta/example.lisp"
+    ]
+  },
+  "blurb": "Convert a resistor band's color to its numeric representation.",
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
+}

--- a/exercises/practice/resistor-color/.meta/example.lisp
+++ b/exercises/practice/resistor-color/.meta/example.lisp
@@ -5,20 +5,8 @@
 
 (in-package :resistor-color)
 
-(defparameter *color-codes*
-  '(("black" . 0)
-    ("brown" . 1)
-    ("red" . 2)
-    ("orange" . 3)
-    ("yellow" . 4)
-    ("green" . 5)
-    ("blue" . 6)
-    ("violet" . 7)
-    ("grey" . 8)
-    ("white" . 9)))
-
 (defun color-code (color)
-  (cdr (assoc color *color-codes* :test #'string=)))
+  (position color (colors) :test #'string=))
 
 (defun colors ()
-  (mapcar #'car *color-codes*))
+  '("black" "brown" "red" "orange" "yellow" "green" "blue" "violet" "grey" "white"))

--- a/exercises/practice/resistor-color/.meta/example.lisp
+++ b/exercises/practice/resistor-color/.meta/example.lisp
@@ -1,0 +1,24 @@
+(defpackage :resistor-color
+  (:use :cl)
+  (:export :color-code
+           :colors))
+
+(in-package :resistor-color)
+
+(defparameter *color-codes*
+  '(("black" . 0)
+    ("brown" . 1)
+    ("red" . 2)
+    ("orange" . 3)
+    ("yellow" . 4)
+    ("green" . 5)
+    ("blue" . 6)
+    ("violet" . 7)
+    ("grey" . 8)
+    ("white" . 9)))
+
+(defun color-code (color)
+  (cdr (assoc color *color-codes* :test #'string=)))
+
+(defun colors ()
+  (mapcar #'car *color-codes*))

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -1,0 +1,15 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[49eb31c5-10a8-4180-9f7f-fea632ab87ef]
+description = "Black"
+
+[0a4df94b-92da-4579-a907-65040ce0b3fc]
+description = "White"
+
+[5f81608d-f36f-4190-8084-f45116b6f380]
+description = "Orange"
+
+[581d68fa-f968-4be2-9f9d-880f2fb73cf7]
+description = "Colors"

--- a/exercises/practice/resistor-color/resistor-color-test.lisp
+++ b/exercises/practice/resistor-color/resistor-color-test.lisp
@@ -1,0 +1,37 @@
+;; Ensures that resistor-color.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "resistor-color")
+  (quicklisp-client:quickload :fiveam))
+
+;; Defines the testing package with symbols from resistor-color and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :resistor-color-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
+
+;; Enter the testing package
+(in-package :resistor-color-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* resistor-color-suite)
+
+(test black
+    (let ((color "black"))
+      (is (= 0 (resistor-color:color-code color)))))
+
+(test white
+    (let ((color "white"))
+      (is (= 9 (resistor-color:color-code color)))))
+
+(test orange
+    (let ((color "orange"))
+      (is (= 3 (resistor-color:color-code color)))))
+
+(test colors
+    (let (
+          (result '("black" "brown" "red" "orange" "yellow" "green" "blue" "violet" "grey" "white")))
+      (is (equal result (resistor-color:colors )))))
+
+(defun run-tests (&optional (test-or-suite 'resistor-color-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/resistor-color/resistor-color.lisp
+++ b/exercises/practice/resistor-color/resistor-color.lisp
@@ -1,0 +1,10 @@
+(defpackage :resistor-color
+  (:use :cl)
+  (:export :color-code
+           :colors))
+
+(in-package :resistor-color)
+
+(defun color-code (color))
+
+(defun colors ())


### PR DESCRIPTION
The huge diff in the track config is because I used `configlet create --practice-exercise` which formats that file. The only relevant bit in that mess is that I gave resistor-color a difficulty of 2.

I can add `resistor-color-duo` next to continue the resistor color series of exercises.