### PR TITLE
Add `square-root`

### DIFF
--- a/config.json
+++ b/config.json
@@ -1315,6 +1315,14 @@
         "difficulty": 1
       },
       {
+        "slug": "square-root",
+        "name": "Square Root",
+        "uuid": "bb0ee09d-5d5c-45d6-949b-b65b04a5f5e7",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "59c87423-c430-4e46-9790-bef60c9c62eb",

--- a/exercises/practice/square-root/.docs/instructions.md
+++ b/exercises/practice/square-root/.docs/instructions.md
@@ -1,0 +1,18 @@
+# Instructions
+
+Your task is to calculate the square root of a given number.
+
+- Try to avoid using the pre-existing math libraries of your language.
+- As input you'll be given a positive whole number, i.e. 1, 2, 3, 4…
+- You are only required to handle cases where the result is a positive whole number.
+
+Some potential approaches:
+
+- Linear or binary search for a number that gives the input number when squared.
+- Successive approximation using Newton's or Heron's method.
+- Calculating one digit at a time or one bit at a time.
+
+You can check out the Wikipedia pages on [integer square root][integer-square-root] and [methods of computing square roots][computing-square-roots] to help with choosing a method of calculation.
+
+[integer-square-root]: https://en.wikipedia.org/wiki/Integer_square_root
+[computing-square-roots]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots

--- a/exercises/practice/square-root/.docs/introduction.md
+++ b/exercises/practice/square-root/.docs/introduction.md
@@ -1,0 +1,10 @@
+# Introduction
+
+We are launching a deep space exploration rocket and we need a way to make sure the navigation system stays on target.
+
+As the first step in our calculation, we take a target number and find its square root (that is, the number that when multiplied by itself equals the target number).
+
+The journey will be very long.
+To make the batteries last as long as possible, we had to make our rocket's onboard computer very power efficient.
+Unfortunately that means that we can't rely on fancy math libraries and functions, as they use more power.
+Instead we want to implement our own square root calculation.

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "square-root.lisp"
+    ],
+    "test": [
+      "square-root-test.lisp"
+    ],
+    "example": [
+      ".meta/example.lisp"
+    ]
+  },
+  "blurb": "Given a natural radicand, return its square root.",
+  "source": "wolf99",
+  "source_url": "https://github.com/exercism/problem-specifications/pull/1582"
+}

--- a/exercises/practice/square-root/.meta/example.lisp
+++ b/exercises/practice/square-root/.meta/example.lisp
@@ -1,0 +1,13 @@
+(defpackage :square-root
+  (:use :cl)
+  (:export :square-root))
+
+(in-package :square-root)
+
+(defun square-root (radicand)
+  (if (= radicand 1)   
+    1
+    (loop with guess = (floor radicand 2)
+          until (= radicand (* guess guess))
+            do (setf guess (floor (+ guess (/ radicand guess)) 2))
+          finally (return guess))))

--- a/exercises/practice/square-root/.meta/example.lisp
+++ b/exercises/practice/square-root/.meta/example.lisp
@@ -8,6 +8,7 @@
   (if (= radicand 1)   
     1
     (loop with guess = (floor radicand 2)
+          repeat 10
           until (= radicand (* guess guess))
             do (setf guess (floor (+ guess (/ radicand guess)) 2))
-          finally (return guess))))
+          finally (return (and (= radicand (* guess guess)) guess)))))

--- a/exercises/practice/square-root/.meta/tests.toml
+++ b/exercises/practice/square-root/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[9b748478-7b0a-490c-b87a-609dacf631fd]
+description = "root of 1"
+
+[7d3aa9ba-9ac6-4e93-a18b-2e8b477139bb]
+description = "root of 4"
+
+[6624aabf-3659-4ae0-a1c8-25ae7f33c6ef]
+description = "root of 25"
+
+[93beac69-265e-4429-abb1-94506b431f81]
+description = "root of 81"
+
+[fbddfeda-8c4f-4bc4-87ca-6991af35360e]
+description = "root of 196"
+
+[c03d0532-8368-4734-a8e0-f96a9eb7fc1d]
+description = "root of 65025"

--- a/exercises/practice/square-root/square-root-test.lisp
+++ b/exercises/practice/square-root/square-root-test.lisp
@@ -1,0 +1,44 @@
+;; Ensures that square-root.lisp and the testing library are always loaded
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (load "square-root")
+  (quicklisp-client:quickload :fiveam))
+
+;; Defines the testing package with symbols from square-root and FiveAM in scope
+;; The `run-tests` function is exported for use by both the user and test-runner
+(defpackage :square-root-test
+  (:use :cl :fiveam)
+  (:export :run-tests))
+
+;; Enter the testing package
+(in-package :square-root-test)
+
+;; Define and enter a new FiveAM test-suite
+(def-suite* square-root-suite)
+
+(test root-of-1
+    (let ((radicand 1))
+      (is (= 1 (square-root:square-root radicand)))))
+
+(test root-of-4
+    (let ((radicand 4))
+      (is (= 2 (square-root:square-root radicand)))))
+
+(test root-of-25
+    (let ((radicand 25))
+      (is (= 5 (square-root:square-root radicand)))))
+
+(test root-of-81
+    (let ((radicand 81))
+      (is (= 9 (square-root:square-root radicand)))))
+
+(test root-of-196
+    (let ((radicand 196))
+      (is (= 14 (square-root:square-root radicand)))))
+
+(test root-of-65025
+    (let ((radicand 65025))
+      (is (= 255 (square-root:square-root radicand)))))
+
+(defun run-tests (&optional (test-or-suite 'square-root-suite))
+  "Provides human readable results of test run. Default to entire suite."
+  (run! test-or-suite))

--- a/exercises/practice/square-root/square-root.lisp
+++ b/exercises/practice/square-root/square-root.lisp
@@ -1,0 +1,7 @@
+(defpackage :square-root
+  (:use :cl)
+  (:export :square-root))
+
+(in-package :square-root)
+
+(defun square-root (radicand))


### PR DESCRIPTION
I had trouble running the exercise generator for this one (see below), so I had to manually generate the files. The example is adapted from my TypeScript implementation for this exercise.

```
(base) ➜  exercism-common-lisp git:(main) python ./bin/lisp_exercise_generator.py 
Enter the path (relative or absolute) to the problem-specifications repository: /home/anagy/Documents/GitHub/exercism-problem-specifications 
Enter the name of the exercise you wish to generate: square-root
You are about to overwrite an existing exercise!  Confirm (Y/N): y
Author's Github handle: BNAndras
Traceback (most recent call last):
  File "/home/anagy/Documents/GitHub/exercism-common-lisp/./bin/lisp_exercise_generator.py", line 465, in <module>
    no_arguments()
  File "/home/anagy/Documents/GitHub/exercism-common-lisp/./bin/lisp_exercise_generator.py", line 410, in no_arguments
    brand_new_exercise(exercise_name, prob_spec_exercise, author)
  File "/home/anagy/Documents/GitHub/exercism-common-lisp/./bin/lisp_exercise_generator.py", line 330, in brand_new_exercise
    create_instructions(exercise_name, prob_spec_exercise)
  File "/home/anagy/Documents/GitHub/exercism-common-lisp/./bin/lisp_exercise_generator.py", line 73, in create_instructions
    with open(input_file, 'r', encoding = "utf-8") as read_from:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/anagy/Documents/GitHub/exercism-problem-specifications/exercises/square-root/description.md'
```