### PR TITLE
Fix house file paths

### DIFF
--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -4,13 +4,13 @@
   ],
   "files": {
     "solution": [
-      "./house.lisp"
+      "house.lisp"
     ],
     "test": [
-      "./house-test.lisp"
+      "house-test.lisp"
     ],
     "example": [
-      "./.meta/example.lisp"
+      ".meta/example.lisp"
     ]
   },
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",


### PR DESCRIPTION
## Summary

The exercise is currently not solvable due to the file paths being incorrect when loaded into the online editor. A separate PR fixes that in the track config.

https://forum.exercism.org/t/the-new-exercise-of-common-lisp-has-bugs/16505/19