### PR TITLE
Add atbash-cipher decode tests

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/example.lisp
+++ b/exercises/practice/atbash-cipher/.meta/example.lisp
@@ -1,6 +1,6 @@
 (defpackage :atbash-cipher
   (:use :common-lisp)
-  (:export :encode))
+  (:export :encode :decode))
 
 (in-package :atbash-cipher)
 
@@ -22,6 +22,11 @@
 
 (defun lookup-char (c) (cdr (assoc c +key+)))
 
+(defun normalize (str)
+  (remove-if-not #'alphanumericp (string-downcase str)))
+
 (defun encode (plaintext)
-  (let ((filtered (remove-if-not #'alphanumericp (string-downcase plaintext))))
-     (to-string (group (map 'list #'lookup-char filtered)))))
+  (to-string (group (map 'list #'lookup-char (normalize plaintext)))))
+
+(defun decode (ciphertext)
+  (map 'string #'lookup-char (normalize ciphertext)))

--- a/exercises/practice/atbash-cipher/atbash-cipher-test.lisp
+++ b/exercises/practice/atbash-cipher/atbash-cipher-test.lisp
@@ -15,29 +15,55 @@
 ;; Define and enter a new FiveAM test-suite
 (def-suite* atbash-cipher-suite)
 
-(test encode-no (is (equal "ml" (atbash-cipher:encode "no"))))
+(def-suite* encode :in atbash-cipher-suite)
 
 (test encode-yes (is (equal "bvh" (atbash-cipher:encode "yes"))))
 
+(test encode-no (is (equal "ml" (atbash-cipher:encode "no"))))
+
 (test encode-omg (is (equal "lnt" (atbash-cipher:encode "OMG"))))
 
-(test encode-o-m-g (is (equal "lnt" (atbash-cipher:encode "O M G"))))
+(test encode-spaces (is (equal "lnt" (atbash-cipher:encode "O M G"))))
 
-(test encode-long-word
- (is (equal "nrmwy oldrm tob" (atbash-cipher:encode "mindblowingly"))))
+(test encode-mindblowingly
+  (is (equal "nrmwy oldrm tob" (atbash-cipher:encode "mindblowingly"))))
 
 (test encode-numbers
  (is
   (equal "gvhgr mt123 gvhgr mt"
          (atbash-cipher:encode "Testing, 1 2 3, testing."))))
 
-(test encode-sentence
- (is (equal "gifgs rhurx grlm" (atbash-cipher:encode "Truth is fiction."))))
+(test encode-deep-thought
+  (is (equal "gifgs rhurx grlm" (atbash-cipher:encode "Truth is fiction."))))
 
-(test encode-all-the-things
+(test encode-all-the-letters
  (let ((plaintext "The quick brown fox jumps over the lazy dog.")
        (cipher "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"))
    (is (equal cipher (atbash-cipher:encode plaintext)))))
+
+(def-suite* decode :in atbash-cipher-suite)
+
+(test decode-exercism
+  (is (equal "exercism" (atbash-cipher:decode "vcvix rhn"))))
+
+(test decode-a-sentence
+  (is (equal "anobstacleisoftenasteppingstone"
+             (atbash-cipher:decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v"))))
+
+(test decode-numbers
+  (is (equal "testing123testing" (atbash-cipher:decode "gvhgr mt123 gvhgr mt"))))
+
+(test decode-all-the-letters
+  (is (equal "thequickbrownfoxjumpsoverthelazydog"
+             (atbash-cipher:decode "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"))))
+
+(test decode-with-too-many-spaces
+  (is (equal "exercism"
+             (atbash-cipher:decode "vc vix    r hn"))))
+
+(test decode-with-no-spaces
+  (is (equal "anobstacleisoftenasteppingstone"
+             (atbash-cipher:decode "zmlyhgzxovrhlugvmzhgvkkrmthglmv"))))
 
 (defun run-tests (&optional (test-or-suite 'atbash-cipher-suite))
   "Provides human readable results of test run. Default to entire suite."

--- a/exercises/practice/atbash-cipher/atbash-cipher.lisp
+++ b/exercises/practice/atbash-cipher/atbash-cipher.lisp
@@ -1,7 +1,9 @@
 (defpackage :atbash-cipher
   (:use :cl)
-  (:export :encode))
+  (:export :encode :decode))
 
 (in-package :atbash-cipher)
 
 (defun encode (plaintext))
+
+(defun decode (ciphertext))


### PR DESCRIPTION
These tests were never implemented (but were listed in the tests.toml
file as if they had been).

Fixes #871