### PR TITLE
Update `acronym` tests

### DIFF
--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -4,7 +4,8 @@
   ],
   "contributors": [
     "daveyarwood",
-    "dnmfarrell"
+    "dnmfarrell",
+    "BNAndras"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/acronym/.meta/example.lisp
+++ b/exercises/practice/acronym/.meta/example.lisp
@@ -1,24 +1,19 @@
-(in-package :cl-user)
 (defpackage :acronym
   (:use :cl)
   (:export :acronym))
 
 (in-package :acronym)
 
-(defun acronym (str)
-  (labels ((recur (st ls)
-    (cond
-      ((equal "" st)
-        ls)
-      ((both-case-p (elt st 0))
-       (recur (string-left-trim
-              "abcdefghijklmnopqrstuvwxyz"
-              (string-left-trim
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                st))
-             (cons (elt st 0)
-                   ls)))
-      (t (recur (subseq st 1) ls)))))
-    (map 'string
-         #'char-upcase
-         (nreverse (recur str nil)))))
+(defun acronym (phrase)
+  (let ((chars ())
+        (inside-word nil))
+    (loop for char across phrase
+          do (cond
+               ((eql char #\')
+                nil)
+               ((and (alpha-char-p char) (not inside-word))
+                (push (char-upcase char) chars)
+                (setf inside-word t))
+               ((not (alpha-char-p char))
+                (setf inside-word nil))))
+    (format nil "~{~A~}" (reverse chars))))

--- a/exercises/practice/acronym/acronym-test.lisp
+++ b/exercises/practice/acronym/acronym-test.lisp
@@ -15,20 +15,41 @@
 ;; Define and enter a new FiveAM test-suite
 (def-suite* acronym-suite)
 
-(test empty-gives-empty (is (equal "" (acronym:acronym ""))))
+(test basic
+    (let ((phrase "Portable Network Graphics"))
+      (is (string= "PNG" (acronym:acronym phrase)))))
 
-(test png-test (is (equal "PNG" (acronym:acronym "Portable Network Graphics"))))
+(test lowercase-words
+    (let ((phrase "Ruby on Rails"))
+      (is (string= "ROR" (acronym:acronym phrase)))))
 
-(test ror-test (is (equal "ROR" (acronym:acronym "Ruby on Rails"))))
+(test punctuation
+    (let ((phrase "First In, First Out"))
+      (is (string= "FIFO" (acronym:acronym phrase)))))
 
-(test fifo-test (is (equal "FIFO" (acronym:acronym "First In, First Out"))))
+(test all-caps-word
+    (let ((phrase "GNU Image Manipulation Program"))
+      (is (string= "GIMP" (acronym:acronym phrase)))))
 
-(test php-test
- (is (equal "PHP" (acronym:acronym "PHP: Hypertext Preprocessor"))))
+(test punctuation-without-whitespace
+    (let ((phrase "Complementary metal-oxide semiconductor"))
+      (is (string= "CMOS" (acronym:acronym phrase)))))
 
-(test cmos-test
- (is
-  (equal "CMOS" (acronym:acronym "Complementary metal-oxide semiconductor"))))
+(test very-long-abbreviation
+    (let ((phrase "Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"))
+      (is (string= "ROTFLSHTMDCOALM" (acronym:acronym phrase)))))
+
+(test consecutive-delimiters
+    (let ((phrase "Something - I made up from thin air"))
+      (is (string= "SIMUFTA" (acronym:acronym phrase)))))
+
+(test apostrophes
+    (let ((phrase "Halley's Comet"))
+      (is (string= "HC" (acronym:acronym phrase)))))
+
+(test underscore-emphasis
+    (let ((phrase "The Road _Not_ Taken"))
+      (is (string= "TRNT" (acronym:acronym phrase)))))
 
 (defun run-tests (&optional (test-or-suite 'acronym-suite))
   "Provides human readable results of test run. Default to entire suite."

--- a/exercises/practice/acronym/acronym.lisp
+++ b/exercises/practice/acronym/acronym.lisp
@@ -4,6 +4,4 @@
 
 (in-package :acronym)
 
-(defun acronym (str)
-  "Returns the acronym for a noun of tech jargon."
-  )
+(defun acronym (phrase))


### PR DESCRIPTION
## Summary

I noticed Acronym was missing a few tests that were marked as included in its test.toml. To that end, I used `./bin/lisp_exercise_generator.py` to generate a new test suite, and then I changed the function name back to acronym:acronym for backwards compatibility. The example solution also had to be updated.