### PR TITLE
Sync `pascals-triangle` tests

### DIFF
--- a/exercises/practice/pascals-triangle/pascals-triangle-test.lisp
+++ b/exercises/practice/pascals-triangle/pascals-triangle-test.lisp
@@ -1,7 +1,7 @@
 ;; Ensures that pascals-triangle.lisp and the testing library are always loaded
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (load "pascals-triangle")
-  (quicklisp-client:quickload :fiveam))
+           (load "pascals-triangle")
+           (quicklisp-client:quickload :fiveam))
 
 ;; Defines the testing package with symbols from pascals-triangle and FiveAM in scope
 ;; The `run-tests` function is exported for use by both the user and test-runner
@@ -15,18 +15,68 @@
 ;; Define and enter a new FiveAM test-suite
 (def-suite* pascals-triangle-suite)
 
-(test zero-rows (is (equal 'nil (pascals-triangle:rows 0))))
+(test zero-rows
+      (let ((count 0))
+        (is (equal '() (pascals-triangle:rows count)))))
 
-(test single-row (is (equal '((1)) (pascals-triangle:rows 1))))
+(test single-row
+      (let ((count 1))
+        (is (equal '((1)) (pascals-triangle:rows count)))))
 
-(test two-rows (is (equal '((1) (1 1)) (pascals-triangle:rows 2))))
+(test two-rows
+      (let ((count 2))
+        (is (equal '((1)
+                     (1 1)) (pascals-triangle:rows count)))))
 
-(test three-rows (is (equal '((1) (1 1) (1 2 1)) (pascals-triangle:rows 3))))
+(test three-rows
+      (let ((count 3))
+        (is (equal '((1)
+                     (1 1)
+                     (1 2 1)) (pascals-triangle:rows count)))))
 
 (test four-rows
- (is (equal '((1) (1 1) (1 2 1) (1 3 3 1)) (pascals-triangle:rows 4))))
+      (let ((count 4))
+        (is (equal '((1)
+                     (1 1)
+                     (1 2 1)
+                     (1 3 3 1)) (pascals-triangle:rows count)))))
 
-(test negative-rows (is (equal 'nil (pascals-triangle:rows -1))))
+(test five-rows
+      (let ((count 5)
+            (result '((1)
+                      (1 1)
+                      (1 2 1)
+                      (1 3 3 1)
+                      (1 4 6 4 1))))
+        (is (equal result (pascals-triangle:rows count)))))
+
+(test six-rows
+      (let ((count 6)
+            (result '((1)
+                      (1 1)
+                      (1 2 1)
+                      (1 3 3 1)
+                      (1 4 6 4 1)
+                      (1 5 10 10 5 1))))
+        (is (equal result (pascals-triangle:rows count)))))
+
+(test ten-rows
+      (let ((count 10)
+            (result '((1)
+                      (1 1)
+                      (1 2 1)
+                      (1 3 3 1)
+                      (1 4 6 4 1)
+                      (1 5 10 10 5 1)
+                      (1 6 15 20 15 6 1)
+                      (1 7 21 35 35 21 7 1)
+                      (1 8 28 56 70 56 28 8 1)
+                      (1 9 36 84 126 126 84 36 9 1))))
+        (is (equal result (pascals-triangle:rows count)))))
+
+(test negative-rows 
+      (let ((count -1))
+        (is (equal 'nil (pascals-triangle:rows count)))))
 
 (defun run-tests (&optional (test-or-suite 'pascals-triangle-suite))
   "Provides human readable results of test run. Default to entire suite."

--- a/exercises/practice/pascals-triangle/pascals-triangle.lisp
+++ b/exercises/practice/pascals-triangle/pascals-triangle.lisp
@@ -1,6 +1,7 @@
 (defpackage :pascals-triangle
   (:use :cl)
   (:export :rows))
+
 (in-package :pascals-triangle)
 
-(defun rows (n))
+(defun rows (count))


### PR DESCRIPTION
## Summary

I redid the tests and stub using the track's test generator to capture a few tests that weren't implemented. I put back the track-specific test for negative rows. There aren't any recent updates to the exercise docs or metadata to sync.