### PR TITLE
Sync `leap` tests

### DIFF
--- a/exercises/practice/leap/leap-test.lisp
+++ b/exercises/practice/leap/leap-test.lisp
@@ -15,15 +15,41 @@
 ;; Define and enter a new FiveAM test-suite
 (def-suite* leap-suite)
 
-(test vanilla-leap-year (is (leap:leap-year-p 1996)))
+(test year-not-divisible-by-4-is-common-year
+    (let ((year 2015))
+      (is-false (leap:leap-year-p year))))
 
-(test any-old-year (is (not (leap:leap-year-p 1997))))
+(test year-divisible-by-2-not-divisible-by-4-is-common-year
+    (let ((year 1970))
+      (is-false (leap:leap-year-p year))))
 
-(test non-leap-even-year (is (not (leap:leap-year-p 1998))))
+(test year-divisible-by-4-not-divisible-by-100-is-leap-year
+    (let ((year 1996))
+      (is-true (leap:leap-year-p year))))
 
-(test century (is (not (leap:leap-year-p 1900))))
+(test year-divisible-by-4-and-5-is-still-a-leap-year
+    (let ((year 1960))
+      (is-true (leap:leap-year-p year))))
 
-(test exceptional-century (is (leap:leap-year-p 2400)))
+(test year-divisible-by-100-not-divisible-by-400-is-common-year
+    (let ((year 2100))
+      (is-false (leap:leap-year-p year))))
+
+(test year-divisible-by-100-but-not-by-3-is-still-not-a-leap-year
+    (let ((year 1900))
+      (is-false (leap:leap-year-p year))))
+
+(test year-divisible-by-400-is-leap-year
+    (let ((year 2000))
+      (is-true (leap:leap-year-p year))))
+
+(test year-divisible-by-400-but-not-by-125-is-still-a-leap-year
+    (let ((year 2400))
+      (is-true (leap:leap-year-p year))))
+
+(test year-divisible-by-200-not-divisible-by-400-is-common-year
+    (let ((year 1800))
+      (is-false (leap:leap-year-p year))))
 
 (defun run-tests (&optional (test-or-suite 'leap-suite))
   "Provides human readable results of test run. Default to entire suite."

--- a/exercises/practice/leap/leap.lisp
+++ b/exercises/practice/leap/leap.lisp
@@ -1,7 +1,7 @@
 (defpackage :leap
   (:use :cl)
   (:export :leap-year-p))
+
 (in-package :leap)
 
-(defun leap-year-p (year)
-  )
+(defun leap-year-p (year))


### PR DESCRIPTION
## Summary

I found some more tests to sync. There are 752 completions to date for this exercise, and the ones that passed the old test suite would probably still pass the new one. You can probably get away with not rerunning those solutions on the updated tests. Up to you.