### PR TITLE
Fix typo in `prime-factors` test name

### DIFF
--- a/exercises/practice/prime-factors/prime-factors-test.lisp
+++ b/exercises/practice/prime-factors/prime-factors-test.lisp
@@ -21,7 +21,7 @@
 (test prime-number
   (is (equal '(2) (prime-factors:factors 2))))
 
-(test another-prime-number]
+(test another-prime-number
   (is (equal '(3) (prime-factors:factors 3))))
 
 (test square-of-a-prime


### PR DESCRIPTION
I noticed a small typo in a test name for `prime-factors`. It wasn't worth rerunning the test generator since there weren't any other tests to sync.