### PR TITLE
Fix typo in isogram-test.lisp

### DIFF
--- a/exercises/practice/isogram/isogram-test.lisp
+++ b/exercises/practice/isogram/isogram-test.lisp
@@ -43,7 +43,7 @@
 
 (test isogram-with-duplicated-hyphen (is (isogram:isogram-p "six-year-old")))
 
-(test made-up-name-that-is-an-isogam
+(test made-up-name-that-is-an-isogram
   (is (isogram:isogram-p "Emily Jung Schwartzkopf")))
 
 (test duplicated-character-in-the-middle


### PR DESCRIPTION
I noticed a small typo in a test name.