### PR TITLE
Fix function name from 'feeding-time-p' to 'feeding-time'

### DIFF
--- a/exercises/concept/pal-picker/.docs/instructions.md
+++ b/exercises/concept/pal-picker/.docs/instructions.md
@@ -59,7 +59,7 @@ One thing all earthling pets have in common is their need for food! This concept
 is somewhat alien to Ludwig, however, as they are prone to forgetting to refill their
 pet's food-bowl.
 
-Ludwig could use a simple function called `feeding-time-p` to alert them when the
+Ludwig could use a simple function called `feeding-time` to alert them when the
 bowl needs refilling. The function would take a percent fullness (an integer)
 and return a message in the form of a string.
 


### PR DESCRIPTION
## Summary

As it's not a predicate, do not return T or NIL we should ditch the `-p` suffix.


## Checklist
- [ ] If docs where changed run `./bin/configlet generate` to ensure all documents are properly generated.
- [ ] CI is green
